### PR TITLE
First Armies Update

### DIFF
--- a/scripts/data/data_armies_book_I.ttslua
+++ b/scripts/data/data_armies_book_I.ttslua
@@ -1,6 +1,6 @@
 armies["Book I"] = {}
 
-armies["Book I"]["I/61b Early Carthaginian 340-275BC"] = {
+armies["Book I"]["I/61a Early Carthaginian 550-341BC"] = {
     data = {
         aggresiveness = 3,
         terrain = 'Litoral',

--- a/scripts/data/data_armies_book_I.ttslua
+++ b/scripts/data/data_armies_book_I.ttslua
@@ -1,17 +1,21 @@
 armies["Book I"] = {}
 
-armies["Book I"]["I/61b Early Carthaginian 409-275BC"] = {
+armies["Book I"]["I/61b Early Carthaginian 340-275BC"] = {
     data = {
         aggresiveness = 3,
         terrain = 'Litoral',
-        list = '1xHCh or 3Cv (Gen), 1xHCh, 1x3Cv, 1x2LH or 3Ax, 4x4Sp, 1x3Ax, 1x4Wb, 2x2Ps.'
+        list = '1x4Sp or 3Cv or HCh (Gen), 1xHCh, 1x3Cv, 4x4Sp, 2x4Sp or 4Ax, 1x4Wb or 3Ax, 2x2Ps.'
     },
-
     base1 = {
-        name = 'HCh_Gen',
-        base = 'tile_grass_40x40',
-        n_models = 1,
-        model_data = 'troop_carthaginian_chariot_gen'
+        name = '4Sp_Gen',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        fixed_models = {
+            [1] = 'troop_carthaginian_soldier',
+            [2] = 'troop_carthaginian_soldier',
+            [3] = 'troop_carthaginian_cavalry_gen',
+            [4] = 'troop_carthaginian_soldier',
+        }
     },
     base2 = {
         name = '3Cv_Gen',
@@ -22,32 +26,30 @@ armies["Book I"]["I/61b Early Carthaginian 409-275BC"] = {
             [2] = 'troop_carthaginian_cavalry_gen',
             [3] = 'troop_carthaginian_cavalry'
         }
-    },    
+    },
     base3 = {
+        name = 'HCh_Gen',
+        base = 'tile_grass_40x40',
+        n_models = 1,
+        model_data = 'troop_carthaginian_chariot_gen'
+    },
+    base4 = {
         name = 'HCh',
         base = 'tile_grass_40x40',
         n_models = 1,
         model_data = 'troop_carthaginian_chariot'
     },
-    base4 = {
+    base5 = {
         name = '3Cv',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_carthaginian_cavalry'
     },
-    base5 = {
-        name = '2LH',
-        base = 'tile_grass_40x30',
-        n_models = 2,
-        model_data = 'troop_carthaginian_lightcav',
-        loose = true
-    },
     base6 = {
-        name = '3Ax',
-        base = 'tile_grass_40x20',
-        n_models = 3,
-        model_data = 'troop_carthaginian_soldier',
-        loose = true
+        name = '4Sp',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_carthaginian_soldier'
     },
     base7 = {
         name = '4Sp',
@@ -74,33 +76,185 @@ armies["Book I"]["I/61b Early Carthaginian 409-275BC"] = {
         model_data = 'troop_carthaginian_soldier'
     },
     base11 = {
+        name = '4Ax',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_carthaginian_psiloi',
+        loose = true
+    },
+    base12 = {
+        name = '4Sp',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_carthaginian_soldier'
+    },
+    base13 = {
+        name = '4Ax',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_carthaginian_psiloi',
+        loose = true
+    },
+    base14 = {
+        name = '4Wb',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_carthaginian_warband'
+    },
+    base15 = {
         name = '3Ax',
         base = 'tile_grass_40x20',
         n_models = 3,
         model_data = 'troop_carthaginian_soldier',
         loose = true
     },
+    base16 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_carthaginian_psiloi',
+        loose = true
+    },
+    base17 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_carthaginian_psiloi',
+        loose = true
+    },
+    base18 = {
+        name = 'Camp',
+        base = 'tile_grass_40x40',
+        n_models = 1,
+        model_data = 'troop_carthaginian_camp'
+    }
+}
+
+
+armies["Book I"]["I/61b Early Carthaginian 340-275BC"] = {
+    data = {
+        aggresiveness = 3,
+        terrain = 'Litoral',
+        list = '1x4Sp or 3Cv or HCh (Gen), 1xHCh, 1x3Cv, 1x2LH or 4Ax, 4x4Sp, 1x4Sp or 4Ax, 1x4Wb or 3Ax, 2x2Ps.'
+    },
+    base1 = {
+        name = '4Sp_Gen',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        fixed_models = {
+            [1] = 'troop_carthaginian_soldier',
+            [2] = 'troop_carthaginian_soldier',
+            [3] = 'troop_carthaginian_cavalry_gen',
+            [4] = 'troop_carthaginian_soldier',
+        }
+    },
+    base2 = {
+        name = '3Cv_Gen',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_carthaginian_cavalry',
+            [2] = 'troop_carthaginian_cavalry_gen',
+            [3] = 'troop_carthaginian_cavalry'
+        }
+    },
+    base3 = {
+        name = 'HCh_Gen',
+        base = 'tile_grass_40x40',
+        n_models = 1,
+        model_data = 'troop_carthaginian_chariot_gen'
+    },
+    base4 = {
+        name = 'HCh',
+        base = 'tile_grass_40x40',
+        n_models = 1,
+        model_data = 'troop_carthaginian_chariot'
+    },
+    base5 = {
+        name = '3Cv',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_carthaginian_cavalry'
+    },
+    base6 = {
+        name = '2LH',
+        base = 'tile_grass_40x30',
+        n_models = 2,
+        model_data = 'troop_carthaginian_lightcav',
+        loose = true
+    },
+    base7 = {
+        name = '4Ax',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_carthaginian_psiloi',
+        loose = true
+    },
+    base8 = {
+        name = '4Sp',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_carthaginian_soldier'
+    },
+    base9 = {
+        name = '4Sp',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_carthaginian_soldier'
+    },
+    base10 = {
+        name = '4Sp',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_carthaginian_soldier'
+    },
+    base11 = {
+        name = '4Sp',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_carthaginian_soldier'
+    },
     base12 = {
+        name = '4Sp',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_carthaginian_soldier'
+    },
+    base13 = {
+        name = '4Ax',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_carthaginian_psiloi',
+        loose = true
+    },
+    base14 = {
         name = '4Wb',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_carthaginian_warband'
     },
-    base13 = {
-        name = '2Ps',
-        base = 'tile_grass_40x20',
-        n_models = 2,
-        model_data = 'troop_carthaginian_psiloi',
-        loose = true
-    },
-    base14 = {
-        name = '2Ps',
-        base = 'tile_grass_40x20',
-        n_models = 2,
-        model_data = 'troop_carthaginian_psiloi',
-        loose = true
-    },
     base15 = {
+        name = '3Ax',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_carthaginian_soldier',
+        loose = true
+    },
+    base16 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_carthaginian_psiloi',
+        loose = true
+    },
+    base17 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_carthaginian_psiloi',
+        loose = true
+    },
+    base18 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,

--- a/scripts/data/data_armies_book_IV.ttslua
+++ b/scripts/data/data_armies_book_IV.ttslua
@@ -1,10 +1,10 @@
 armies["Book IV"] = {}
 
-armies["Book IV"]["IV/13c Medieval German 1450-1478AD"] = {
+armies["Book IV"]["IV/13c.1 Medieval German 1440-1493AD"] = {
     data = {
         aggresiveness = 1,
         terrain = 'Arable',
-        list = '1x6Kn (Gen), 2x6Kn, 1x3Cv, 2x4Pk, 2x3/4Sp, 1x4Cb or 2Ps, 2xWWg, 1xArt.'
+        list = '1x6Kn (Gen), 2x6Kn, 1x3Cv, 1x3Cv or 4Cb, 2x4Pk, 2x4Cb or WWg, 1x4Cb, 1x2Ps,1x2Ps or Art'
     },
     base1 = {
         name = '6Kn_Gen',
@@ -38,78 +38,72 @@ armies["Book IV"]["IV/13c Medieval German 1450-1478AD"] = {
         model_data = 'troop_horse_rider_late_medieval'
     },
     base5 = {
+        name = '3Cv',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base6 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base7 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_swiss_straight'
     },
-    base6 = {
+    base8 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_swiss_inclined'
     },
-    base7 = {
-        name = '4Sp',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_spearman_late_medieval'
-    },
-    base8 = {
-        name = '4Sp',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_spearman_late_medieval'
-    },
     base9 = {
-        name = '3Sp',
-        base = 'tile_grass_40x20',
-        n_models = 3,
-        model_data = 'troop_spearman_no_shield_late_medieval'
-    },
-    base10 = {
-        name = '3Sp',
-        base = 'tile_grass_40x20',
-        n_models = 3,
-        model_data = 'troop_spearman_no_shield_late_medieval'
-    },
-    base11 = {
         name = '4Cb',
         base = 'tile_grass_40x20',
         n_models = 4,
         model_data = 'troop_crossbowman_late_medieval'
     },
+    base10 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base11 = {
+        name = 'WWg',
+        base = 'tile_grass_40x80',
+        n_models = 1,
+        model_data = 'troop_war_wagon_late_medieval'
+    },
     base12 = {
+        name = 'WWg',
+        base = 'tile_grass_40x80',
+        n_models = 1,
+        model_data = 'troop_war_wagon_late_medieval'
+    },
+    base13 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base14 = {
         name = '2Ps',
         base = 'tile_grass_40x20',
         n_models = 2,
         model_data = 'troop_bowman_late_medieval'
     },
-    base13 = {
-        name = 'WWg',
-        base = 'tile_grass_40x80',
-        n_models = 1,
-        model_data = 'troop_war_wagon_late_medieval'
-    },
-    base14 = {
-        name = 'WWg',
-        base = 'tile_grass_40x80',
-        n_models = 1,
-        model_data = 'troop_war_wagon_late_medieval'
-    },
     base15 = {
-        name = '4Cb',
+        name = '2Ps',
         base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_crossbowman_late_medieval'
+        n_models = 2,
+        model_data = 'troop_bowman_late_medieval'
     },
     base16 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_crossbowman_late_medieval'
-    },
-    base17 = {
         name = 'Art',
         base = 'tile_grass_40x40',
         n_models = 3,
@@ -119,7 +113,7 @@ armies["Book IV"]["IV/13c Medieval German 1450-1478AD"] = {
             [3] = 'troop_artillery_crew_late_medieval'
         }
     },
-    base18 = {
+    base17 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -127,11 +121,133 @@ armies["Book IV"]["IV/13c Medieval German 1450-1478AD"] = {
     }
 }
 
-armies["Book IV"]["IV/13d Medieval German 1479-1519AD"] = {
+armies["Book IV"]["IV/13c.2 Medieval German 1440-1493AD"] = {
+    data = {
+        aggresiveness = 2,
+        terrain = 'Arable',
+        list = '1x6Kn (Gen), 2x6Kn, 1x3Cv, 1x3Cv or 4Cb, 2x4Pk, 2x4Cb or WWg, 1x7Hd, 1x2Ps,1x2Ps or Art'
+    },
+    base1 = {
+        name = '6Kn_Gen',
+        base = 'tile_grass_40x60',
+        n_models = 6,
+        fixed_models = {
+            [1] = 'troop_knight_late_medieval',
+            [2] = 'troop_knight_late_medieval',
+            [3] = 'troop_knight_late_medieval',
+            [4] = 'troop_knight_late_medieval',
+            [5] = 'troop_knight_late_medieval_captain',
+            [6] = 'troop_knight_late_german_c_bannerman'
+        }
+    },
+    base2 = {
+        name = '6Kn',
+        base = 'tile_grass_40x60',
+        n_models = 6,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base3 = {
+        name = '6Kn',
+        base = 'tile_grass_40x60',
+        n_models = 6,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base4 = {
+        name = '3Cv',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base5 = {
+        name = '3Cv',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base6 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base7 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_swiss_straight'
+    },
+    base8 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_swiss_inclined'
+    },
+    base9 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base10 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base11 = {
+        name = 'WWg',
+        base = 'tile_grass_40x80',
+        n_models = 1,
+        model_data = 'troop_war_wagon_late_medieval'
+    },
+    base12 = {
+        name = 'WWg',
+        base = 'tile_grass_40x80',
+        n_models = 1,
+        model_data = 'troop_war_wagon_late_medieval'
+    },
+    base13 = {
+        name = '7Hd',
+        base = 'tile_grass_40x30',
+        n_models = 7,
+        loose = true,
+        model_data = 'troop_horde_late_medieval'
+    },
+    base14 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_bowman_late_medieval'
+    },
+    base15 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_bowman_late_medieval'
+    },
+    base16 = {
+        name = 'Art',
+        base = 'tile_grass_40x40',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_artillery_crew_late_medieval',
+            [2] = 'troop_artillery_pieces_late_medieval',
+            [3] = 'troop_artillery_crew_late_medieval'
+        }
+    },
+    base17 = {
+        name = 'Camp',
+        base = 'tile_grass_40x40',
+        n_models = 1,
+        model_data = 'troop_camp_late_german_c'
+    }
+}
+
+armies["Book IV"]["IV/13d Medieval German 1494-1518AD"] = {
     data = {
         aggresiveness = 1,
         terrain = 'Arable',
-        list = '1x6Kn (Gen), 2x6Kn, 1x3Cv, 2x4Pk, 2x3/4Sp, 1x4Cb or 2Ps, 2xWWg, 1xArt.'
+        list = '1x3Kn or 4Pk (Gen), 1x3Kn or 4Pk or 3Bd, 2x6Kn, 1x3Cv, 4x4Pk, 2x2Ps, 1xArt.'
     },
     base1 = {
         name = '3Kn_Gen',
@@ -140,7 +256,7 @@ armies["Book IV"]["IV/13d Medieval German 1479-1519AD"] = {
         fixed_models = {
             [1] = 'troop_knight_late_german_d_bannerman',
             [2] = 'troop_knight_late_medieval_captain',
-            [3] = 'troop_knight_late_medieval'
+            [3] = 'troop_knight_burgundian'
         }
     },
     base2 = {
@@ -151,7 +267,7 @@ armies["Book IV"]["IV/13d Medieval German 1479-1519AD"] = {
             [1] = 'troop_pikeman_late_medieval_straight',
             [2] = 'troop_pikeman_late_medieval_captain',
             [3] = 'troop_pikeman_late_german_d_bannerman',
-            [4] = 'troop_pikeman_late_medieval_straight',
+            [4] = 'troop_pikeman_late_medieval_straight'
         }
     },
     base3 = {
@@ -161,60 +277,72 @@ armies["Book IV"]["IV/13d Medieval German 1479-1519AD"] = {
         model_data = 'troop_knight_late_medieval'
     },
     base4 = {
-        name = '6Kn',
-        base = 'tile_grass_40x60',
-        n_models = 6,
-        model_data = 'troop_knight_late_medieval'
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
     },
     base5 = {
+        name = '3Bd',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_swordman_two_handed_late_medieval'
+    },
+    base6 = {
         name = '6Kn',
         base = 'tile_grass_40x60',
         n_models = 6,
         model_data = 'troop_knight_late_medieval'
     },
-    base6 = {
+    base7 = {
+        name = '6Kn',
+        base = 'tile_grass_40x60',
+        n_models = 6,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base8 = {
         name = '3Cv',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_horse_rider_late_medieval'
     },
-    base7 = {
+    base9 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_late_medieval_straight'
     },
-    base8 = {
-        name = '4Pk',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_inclined'
-    },
-    base9 = {
-        name = '4Pk',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_inclined'
-    },
     base10 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
+    },
+    base11 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
+    },
+    base12 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
+    },
+    base13 = {
         name = '2Ps',
         base = 'tile_grass_40x20',
         n_models = 2,
-        model_data = 'troop_bowman_late_medieval'
+        model_data = 'troop_handgunner_late_medieval'
     },
-    base11 = {
-        name = 'WWg',
-        base = 'tile_grass_40x80',
-        n_models = 1,
-        model_data = 'troop_war_wagon_late_medieval'
+    base14 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_handgunner_late_medieval'
     },
-    base12 = {
-        name = 'WWg',
-        base = 'tile_grass_40x80',
-        n_models = 1,
-        model_data = 'troop_war_wagon_late_medieval'
-    },
-    base13 = {
+    base15 = {
         name = 'Art',
         base = 'tile_grass_40x40',
         n_models = 3,
@@ -224,7 +352,7 @@ armies["Book IV"]["IV/13d Medieval German 1479-1519AD"] = {
             [3] = 'troop_artillery_crew_late_medieval'
         }
     },
-    base14 = {
+    base16 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -232,11 +360,11 @@ armies["Book IV"]["IV/13d Medieval German 1479-1519AD"] = {
     }
 }
 
-armies["Book IV"]["IV/56b Order of Saint John 1451-1522AD"] = {
+armies["Book IV"]["IV/56b Order of Saint John 1291-1522AD"] = {
     data = {
         aggresiveness = 1,
         terrain = 'Litoral',
-        list = '1x3Kn or 4Bd (Gen), 1x3Kn or 4Bd, 2x4Cb, 1x4Bd, 1x4Sp, 1x3Cb, 5x2Ps.'
+        list = '1x3Kn or 4Bd (Gen), 1x3Kn or 4Bd, 2x4Sp, 2x3/4Cb, 6x2Ps.'
     },
     base1 = {
         name = '3Kn_Gen',
@@ -272,28 +400,28 @@ armies["Book IV"]["IV/56b Order of Saint John 1451-1522AD"] = {
         model_data = 'troop_swordman_two_handed_late_medieval'
     },
     base5 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_crossbowman_burgundian_ordonnances'
-    },
-    base6 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_crossbowman_burgundian_ordonnances'
-    },
-    base7 = {
-        name = '4Bd',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_swordman_late_medieval'
-    },
-    base8 = {
         name = '4Sp',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_spearman_late_medieval'
+    },
+    base6 = {
+        name = '4Sp',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_spearman_late_medieval'
+    },
+    base7 = {
+        name = '3Cb',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base8 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_burgundian_ordonnances'
     },
     base9 = {
         name = '3Cb',
@@ -302,16 +430,16 @@ armies["Book IV"]["IV/56b Order of Saint John 1451-1522AD"] = {
         model_data = 'troop_crossbowman_late_medieval'
     },
     base10 = {
-        name = '2Ps',
+        name = '4Cb',
         base = 'tile_grass_40x20',
-        n_models = 2,
-        model_data = 'troop_bowman_late_medieval'
+        n_models = 4,
+        model_data = 'troop_crossbowman_burgundian_ordonnances'
     },
     base11 = {
         name = '2Ps',
         base = 'tile_grass_40x20',
         n_models = 2,
-        model_data = 'troop_crossbowman_late_medieval'
+        model_data = 'troop_bowman_late_medieval'
     },
     base12 = {
         name = '2Ps',
@@ -332,6 +460,18 @@ armies["Book IV"]["IV/56b Order of Saint John 1451-1522AD"] = {
         model_data = 'troop_bowman_late_medieval'
     },
     base15 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base16 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_bowman_late_medieval'
+    },
+    base17 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -343,19 +483,9 @@ armies["Book IV"]["IV/57c Low Countries 1411-1478AD"] = {
     data = {
         aggresiveness = 0,
         terrain = 'Arable',
-        list = '1x3Kn o 4Pk (Gen), 1x3Kn o 4Pk, 1x4Cb, 6x4Pk, 1x4Bd o 4Pk, 1x2Ps, 1x4Pk o Art.'
+        list = '1x4Pk (Gen), 7x4Pk, 1x4Bd, 1x4Cb or 2Ps, 1x2Ps, 1xArt.'
     },
     base1 = {
-        name = '3Kn_Gen',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        fixed_models = {
-            [1] = 'troop_knight_late_medieval',
-            [2] = 'troop_knight_late_medieval_captain',
-            [3] = 'troop_knight_low_countries_bannerman'
-        }
-    },
-    base2 = {
         name = '4Pk_Gen',
         base = 'tile_grass_40x15',
         n_models = 4,
@@ -366,11 +496,17 @@ armies["Book IV"]["IV/57c Low Countries 1411-1478AD"] = {
             [4] = 'troop_pikeman_late_medieval_inclined'
         }
     },
+    base2 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
+    },
     base3 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
     },
     base4 = {
         name = '4Pk',
@@ -379,22 +515,22 @@ armies["Book IV"]["IV/57c Low Countries 1411-1478AD"] = {
         model_data = 'troop_pikeman_late_medieval_inclined'
     },
     base5 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
+        name = '4Pk',
+        base = 'tile_grass_40x15',
         n_models = 4,
-        model_data = 'troop_crossbowman_late_medieval'
+        model_data = 'troop_pikeman_late_medieval_straight'
     },
     base6 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_inclined'
+        model_data = 'troop_pikeman_late_medieval_straight'
     },
     base7 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_inclined'
+        model_data = 'troop_pikeman_late_medieval_straight'
     },
     base8 = {
         name = '4Pk',
@@ -409,42 +545,24 @@ armies["Book IV"]["IV/57c Low Countries 1411-1478AD"] = {
         model_data = 'troop_pikeman_late_medieval_straight'
     },
     base10 = {
-        name = '4Pk',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_straight'
-    },
-    base11 = {
-        name = '4Pk',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_straight'
-    },
-    base12 = {
         name = '4Bd',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_halberdier_late_medieval'
     },
-    base13 = {
-        name = '4Pk',
-        base = 'tile_grass_40x15',
+    base11 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
         n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_straight'
+        model_data = 'troop_crossbowman_late_medieval'
     },
-    base14 = {
+    base12 = {
         name = '2Ps',
         base = 'tile_grass_40x20',
         n_models = 2,
         model_data = 'troop_handgunner_late_medieval'
     },
-    base15 = {
-        name = '4Pk',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_inclined'
-    },
-    base16 = {
+    base13 = {
         name = 'Art',
         base = 'tile_grass_40x40',
         n_models = 3,
@@ -454,7 +572,7 @@ armies["Book IV"]["IV/57c Low Countries 1411-1478AD"] = {
             [3] = 'troop_artillery_crew_late_medieval'
         }
     },
-    base17 = {
+    base14 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -466,7 +584,7 @@ armies["Book IV"]["IV/61 Italian Condotta 1320-1515AD"] = {
     data = {
         aggresiveness = 1,
         terrain = 'Litoral (if Venice or Genoa), otherwise Arable',
-        list = '1x3Kn (Gen), 4x3Kn, 1x2LH, 2x8Cb or 2Ps, 2x4Sp or 4Pk, 1x4Cb or 4Ax or 3Bd or 2LH, 1x2Ps or Art.'
+        list = '1x3Kn (Gen), 4x3Kn, 1x2LH, 2x4/8Cb or 2Ps, 2x4Sp or 4Pk, 1x4Ax or 3Bd or 7Hd, 1x3Kn or 4Lb or Art.'
     },
 
     base1 = {
@@ -510,9 +628,9 @@ armies["Book IV"]["IV/61 Italian Condotta 1320-1515AD"] = {
         model_data = 'troop_horse_rider_late_medieval'
     },
     base7 = {
-        name = '8Cb',
-        base = 'tile_grass_40x40',
-        n_models = 8,
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
         model_data = 'troop_crossbowman_late_medieval'
     },
     base8 = {
@@ -528,76 +646,94 @@ armies["Book IV"]["IV/61 Italian Condotta 1320-1515AD"] = {
         model_data = 'troop_crossbowman_late_medieval'
     },
     base10 = {
-        name = '2Ps',
-        base = 'tile_grass_40x20',
-        n_models = 2,
-        model_data = 'troop_crossbowman_late_medieval'
-    },
-    base11 = {
-        name = '4Sp',
-          base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_spearman_late_medieval'
-    },
-    base12 = {
-        name = '4Sp',
-          base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_spearman_late_medieval'
-    },
-    base13 = {
-        name = '4Pk',
-          base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_straight'
-    },
-    base14 = {
-        name = '4Pk',
-          base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_late_medieval_inclined'
-    },
-    base15 = {
         name = '4Cb',
         base = 'tile_grass_40x20',
         n_models = 4,
         model_data = 'troop_crossbowman_late_medieval'
     },
-    base16 = {
-        name = '4Ax',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_spearman_no_shield_late_medieval'
+    base11 = {
+        name = '8Cb',
+        base = 'tile_grass_40x40',
+        n_models = 8,
+        model_data = 'troop_crossbowman_late_medieval'
     },
-    base17 = {
-        name = '3Bd',
-        base = 'tile_grass_40x20',
-        n_models = 3,
-        model_data = 'troop_swordman_late_medieval'
-    },
-    base18 = {
-        name = '2LH',
-        base = 'tile_grass_40x30',
-        n_models = 2,
-        model_data = 'troop_horse_rider_late_medieval'
-    },
-    base19 = {
+    base12 = {
         name = '2Ps',
         base = 'tile_grass_40x20',
         n_models = 2,
         model_data = 'troop_crossbowman_late_medieval'
     },
+    base13 = {
+        name = '4Sp',
+          base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_spearman_late_medieval'
+    },
+    base14 = {
+        name = '4Sp',
+          base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_spearman_late_medieval'
+    },
+    base15 = {
+        name = '4Pk',
+          base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_straight'
+    },
+    base16 = {
+        name = '4Pk',
+          base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
+    },
+    base17 = {
+        name = '4Ax',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_spearman_no_shield_late_medieval'
+    },
+    base18 = {
+        name = '3Bd',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_swordman_late_medieval'
+    },
+    base19 = {
+        name = '7Hd',
+        base = 'tile_grass_40x30',
+        n_models = 7,
+        model_data = 'troop_horde_late_medieval'
+    },
     base20 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base21 = {
+        name = '4Lb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_longbowman_late_medieval'
+    },
+    base22 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base23 = {
         name = 'Art',
         base = 'tile_grass_40x40',
         n_models = 3,
         fixed_models = {
-            [1] = 'troop_artillery_crew_swiss',
-            [2] = 'troop_artillery_pieces_swiss',
-            [3] = 'troop_artillery_crew_swiss'
+            [1] = 'troop_artillery_crew_late_medieval',
+            [2] = 'troop_artillery_pieces_late_medieval',
+            [3] = 'troop_artillery_crew_late_medieval'
         }
     },
-    base21 = {
+    base24 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -609,7 +745,7 @@ armies["Book IV"]["IV/66 Later Polish 1335-1510AD"] = {
     data = {
         aggresiveness = 1,
         terrain = 'Forest',
-        list = '1x3Kn (Gen), 3x3Kn, 4x3Cv, 1x2LH, 1x3Bd o 2LH, 1x8Cb, 1xWWg o 8Cb.'
+        list = '1x3Kn (Gen), 3x3Kn, 3x3Cv, 2x2LH, 1x3Bd o 3Cv, 2x8Cb or WWg or 3Cv.'
     },
 
     base1 = {
@@ -659,9 +795,9 @@ armies["Book IV"]["IV/66 Later Polish 1335-1510AD"] = {
         model_data = 'troop_horse_rider_late_medieval'
     },
     base8 = {
-        name = '3Cv',
+        name = '2LH',
         base = 'tile_grass_40x30',
-        n_models = 3,
+        n_models = 2,
         model_data = 'troop_horse_rider_late_medieval'
     },
     base9 = {
@@ -677,9 +813,9 @@ armies["Book IV"]["IV/66 Later Polish 1335-1510AD"] = {
         model_data = 'troop_swordman_two_handed_late_medieval'
     },
     base11 = {
-        name = '2LH',
+        name = '3Cv',
         base = 'tile_grass_40x30',
-        n_models = 2,
+        n_models = 3,
         model_data = 'troop_horse_rider_late_medieval'
     },
     base12 = {
@@ -695,121 +831,30 @@ armies["Book IV"]["IV/66 Later Polish 1335-1510AD"] = {
         model_data = 'troop_war_wagon_late_medieval'
     },
     base14 = {
+        name = '3Cv',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base15 = {
         name = '8Cb',
         base = 'tile_grass_40x40',
         n_models = 8,
         model_data = 'troop_crossbowman_late_medieval'
     },
-    base15 = {
-        name = 'Camp',
-        base = 'tile_grass_40x40',
-        n_models = 1,
-        model_data = 'troop_camp_late_medieval'
-    }
-}
-
-armies["Book IV"]["IV/68a Medieval Spanish 1340-1485AD"] = {
-    data = {
-        aggresiveness = 3,
-        terrain = 'Arable',
-        list = '1x3Kn (Gen), 2x3Kn, 1x3Kn//4Bd or 4Lb or 2LH, 2x2LH, 1x4Sp, 2x3Ax, 1x4Cb, 2x2Ps.'
-    },
-
-    base1 = {
-        name = '3Kn_Gen',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        fixed_models = {
-            [1] = 'troop_knight_medieval_spanish_bannerman',
-            [2] = 'troop_knight_late_medieval_captain',
-            [3] = 'troop_knight_late_medieval'
-        }
-    },
-    base2 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
-    },
-    base3 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
-    },
-    base4 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
-    },
-    base5 = {
-        name = '4Bd',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_swordman_two_handed_late_medieval'
-    },
-    base6 = {
-        name = '4Lb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base7 = {
-        name = '2LH',
-        base = 'tile_grass_40x30',
-        n_models = 2,
-        model_data = 'troop_horse_rider_late_medieval'
-    },
-    base8 = {
-        name = '2LH',
-          base = 'tile_grass_40x30',
-        n_models = 2,
-        model_data = 'troop_horse_rider_late_medieval'
-    },
-    base9 = {
-        name = '2LH',
-        base = 'tile_grass_40x30',
-        n_models = 2,
-        model_data = 'troop_horse_rider_late_medieval'
-    },
-    base10 = {
-        name = '4Sp',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_spearman_late_medieval'
-    },
-    base11 = {
-        name = '3Ax',
-        base = 'tile_grass_40x20',
-        n_models = 3,
-        model_data = 'troop_spearman_no_shield_late_medieval'
-    },
-    base12 = {
-        name = '3Ax',
-        base = 'tile_grass_40x20',
-        n_models = 3,
-        model_data = 'troop_spearman_no_shield_late_medieval'
-    },
-    base13 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_crossbowman_late_medieval'
-    },
-    base14 = {
-        name = '2Ps',
-        base = 'tile_grass_40x20',
-        n_models = 2,
-        model_data = 'troop_bowman_late_medieval'
-    },
-    base15 = {
-        name = '2Ps',
-        base = 'tile_grass_40x20',
-        n_models = 2,
-        model_data = 'troop_bowman_late_medieval'
-    },
     base16 = {
+        name = 'WWg',
+        base = 'tile_grass_40x80',
+        n_models = 1,
+        model_data = 'troop_war_wagon_late_medieval'
+    },
+    base17 = {
+        name = '3Cv',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base18 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -821,7 +866,7 @@ armies["Book IV"]["IV/68b Medieval Portuguese 1340-1485AD"] = {
     data = {
         aggresiveness = 3,
         terrain = 'Arable',
-        list = '1x3Kn//4Bd (Gen), 3x3Kn//4Bd, 1x2LH, 1x4Sp, 2x3Ax, 2x2Ps or 4Cb, 2x4Lb or 4Cb.'
+        list = '1x3Kn//4Bd (Gen), 3x3Kn//4Bd, 1x2LH, 2x3Pk, 2x3Bd, 3x2Ps.'
     },
 
     base1 = {
@@ -888,72 +933,48 @@ armies["Book IV"]["IV/68b Medieval Portuguese 1340-1485AD"] = {
         model_data = 'troop_horse_rider_late_medieval'
     },
     base10 = {
-        name = '4Sp',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_spearman_late_medieval'
+        name = '3Pk',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_pikeman_late_medieval_straight'
     },
     base11 = {
-        name = '3Ax',
+        name = '3Pk',
         base = 'tile_grass_40x20',
         n_models = 3,
-        model_data = 'troop_spearman_no_shield_late_medieval'
+        model_data = 'troop_pikeman_late_medieval_inclined'
     },
     base12 = {
-        name = '3Ax',
+        name = '3Bd',
         base = 'tile_grass_40x20',
         n_models = 3,
-        model_data = 'troop_spearman_no_shield_late_medieval'
+        model_data = 'troop_swordman_late_medieval'
     },
     base13 = {
-        name = '2Ps',
+        name = '3Bd',
         base = 'tile_grass_40x20',
-        n_models = 2,
-        model_data = 'troop_bowman_late_medieval'
+        n_models = 3,
+        model_data = 'troop_swordman_late_medieval'
     },
     base14 = {
         name = '2Ps',
         base = 'tile_grass_40x20',
         n_models = 2,
-        model_data = 'troop_bowman_late_medieval'
-    },
-    base15 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
         model_data = 'troop_crossbowman_late_medieval'
     },
-    base16 = {
-        name = '4Cb',
+    base15 = {
+        name = '2Ps',
         base = 'tile_grass_40x20',
-        n_models = 4,
+        n_models = 2,
+        model_data = 'troop_handgunner_late_medieval'
+    },
+    base16 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
         model_data = 'troop_crossbowman_late_medieval'
     },
     base17 = {
-        name = '4Lb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base18 = {
-        name = '4Lb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base19 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_crossbowman_late_medieval'
-    },
-    base20 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_crossbowman_late_medieval'
-    },
-    base21 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -961,13 +982,195 @@ armies["Book IV"]["IV/68b Medieval Portuguese 1340-1485AD"] = {
     }
 }
 
-armies["Book IV"]["IV/79 Late Swiss 1400-1522AD"] = {
+armies["Book IV"]["IV/68e Medieval Spanish 1495-1503AD"] = {
+    data = {
+        aggresiveness = 3,
+        terrain = 'Arable',
+        list = '1x3Kn (Gen), 3x3Kn, 2x2LH, 2x3Pk, 2x3Bd, 2x2Ps.'
+    },
+
+    base1 = {
+        name = '3Kn_Gen',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_knight_medieval_spanish_bannerman',
+            [2] = 'troop_knight_late_medieval_captain',
+            [3] = 'troop_knight_late_medieval'
+        }
+    },
+    base2 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base3 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base4 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base5 = {
+        name = '2LH',
+        base = 'tile_grass_40x30',
+        n_models = 2,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base6 = {
+        name = '2LH',
+          base = 'tile_grass_40x30',
+        n_models = 2,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base7 = {
+        name = '3Pk',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_pikeman_late_medieval_straight'
+    },
+    base8 = {
+        name = '3Pk',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_pikeman_late_medieval_inclined'
+    },
+    base9 = {
+        name = '3Bd',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_swordman_late_medieval'
+    },
+    base10 = {
+        name = '3Bd',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_swordman_late_medieval'
+    },
+    base11 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base12 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_handgunner_late_medieval'
+    },
+    base13 = {
+        name = 'Camp',
+        base = 'tile_grass_40x40',
+        n_models = 1,
+        model_data = 'troop_camp_late_medieval'
+    }
+}
+
+armies["Book IV"]["IV/68f Medieval Spanish 1504-1515AD"] = {
+    data = {
+        aggresiveness = 3,
+        terrain = 'Arable',
+        list = '1x3Kn (Gen), 2x3Kn, 1x2LH, 4x4Pk, 2x3Bd, 2x2Ps.'
+    },
+
+    base1 = {
+        name = '3Kn_Gen',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_knight_medieval_spanish_bannerman',
+            [2] = 'troop_knight_late_medieval_captain',
+            [3] = 'troop_knight_late_medieval'
+        }
+    },
+    base2 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base3 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base4 = {
+        name = '2LH',
+          base = 'tile_grass_40x30',
+        n_models = 2,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base5 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_straight'
+    },
+    base6 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_straight'
+    },
+    base7 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
+    },
+    base8 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_inclined'
+    },
+    base9 = {
+        name = '3Bd',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_swordman_late_medieval'
+    },
+    base10 = {
+        name = '3Bd',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_swordman_late_medieval'
+    },
+    base11 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base12 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_handgunner_late_medieval'
+    },
+    base13 = {
+        name = 'Camp',
+        base = 'tile_grass_40x40',
+        n_models = 1,
+        model_data = 'troop_camp_late_medieval'
+    }
+}
+
+armies["Book IV"]["IV/79d Late Swiss 1478-1522AD"] = {
     data = {
         aggresiveness = 3,
         terrain = 'Mountain',
-        list = '1x4Pk (Gen), 1x6Kn o 6Bd, 7x4Pk, 2x2Ps, 1x2LH or Art.'
+        list = '1x4Pk (Gen), 9x4Pk, 1x2Ps, 1x2Ps or Art or 3/4Bd.'
     },
-    
+
     base1 = {
         name = '4Pk_Gen',
         base = 'tile_grass_40x15',
@@ -1022,16 +1225,16 @@ armies["Book IV"]["IV/79 Late Swiss 1400-1522AD"] = {
         model_data = 'troop_pikeman_swiss_straight'
     },
     base9 = {
-        name = '6Kn',
-        base = 'tile_grass_40x60',
-        n_models = 6,
-        model_data = 'troop_knight_swiss'
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_swiss_straight'
     },
     base10 = {
-        name = '6Bd',
-        base = 'tile_grass_40x30',
-        n_models = 6,
-        model_data = 'troop_halberdier_swiss'
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_swiss_straight'
     },
     base11 = {
         name = '2Ps',
@@ -1046,12 +1249,6 @@ armies["Book IV"]["IV/79 Late Swiss 1400-1522AD"] = {
         model_data = 'troop_handgunner_swiss'
     },
     base13 = {
-        name = '2LH',
-        base = 'tile_grass_40x30',
-        n_models = 2,
-        model_data = 'troop_horse_rider_swiss'
-    },
-    base14 = {
         name = 'Art',
         base = 'tile_grass_40x40',
         n_models = 3,
@@ -1061,7 +1258,19 @@ armies["Book IV"]["IV/79 Late Swiss 1400-1522AD"] = {
             [3] = 'troop_artillery_crew_swiss'
         }
     },
+    base14 = {
+        name = '3Bd',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_halberdier_swiss'
+    },
     base15 = {
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_swiss'
+    },
+    base16 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -1069,11 +1278,11 @@ armies["Book IV"]["IV/79 Late Swiss 1400-1522AD"] = {
     }
 }
 
-armies["Book IV"]["IV/82a French Ordonnances 1445-1464AD"] = {
+armies["Book IV"]["IV/82a French Ordonnances 1445-1480AD"] = {
     data = {
         aggresiveness = 2,
         terrain = 'Arable',
-        list = '1x3Kn//4Bw (Gen), 4x3Kn//4Bd, 1x4Cb, 1x4Bw, 2x3Bw, 1x4Bd or Art, 1x2Ps, 1xArt.'
+        list = '1x3Kn or Mtd-4Lb//4Bw (Gen), 3x3Kn//4Bd, 1x3Kn or Mtd-4Lb, 4x3Bw, 1x4Bd or 4Cb or 2Ps, 2xArt or 7Hd'
     },
     base1 = {
         name = '3Kn_Gen',
@@ -1086,6 +1295,17 @@ armies["Book IV"]["IV/82a French Ordonnances 1445-1464AD"] = {
         }
     },
     base2 = {
+        name = '4Bw_Mtd_Gen',
+        base = 'tile_grass_40x40',
+        n_models = 4,
+        fixed_models = {
+            [1] = 'troop_horse_rider_late_medieval',
+            [2] = 'troop_knight_late_medieval_captain',
+            [3] = 'troop_knight_french_ordonnances_a_bannerman',
+            [4] = 'troop_horse_rider_late_medieval'
+        }
+    },
+    base3 = {
         name = '4Bw_Gen',
         base = 'tile_grass_40x15',
         n_models = 4,
@@ -1096,64 +1316,59 @@ armies["Book IV"]["IV/82a French Ordonnances 1445-1464AD"] = {
             [4] = 'troop_bowman_late_medieval'
         }
     },
-    base3 = {
+    base4 = {
         name = '3Kn',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_knight_late_medieval'
-    },
-    base4 = {
-        name = '4Bd',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_swordman_two_handed_late_medieval'
     },
     base5 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_swordman_two_handed_late_medieval'
     },
     base6 = {
-        name = '4Bd',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_swordman_two_handed_late_medieval'
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
     },
     base7 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_swordman_two_handed_late_medieval'
     },
     base8 = {
-        name = '4Bd',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_swordman_two_handed_late_medieval'
-    },
-    base9 = {
         name = '3Kn',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_knight_late_medieval'
     },
-    base10 = {
+    base9 = {
         name = '4Bd',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_swordman_two_handed_late_medieval'
     },
+    base10 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
+    },
     base11 = {
-        name = '4Cb',
-        base = 'tile_grass_40x20',
+        name = '4Lb_Mtd',
+        base = 'tile_grass_40x40',
         n_models = 4,
-        model_data = 'troop_crossbowman_late_medieval'
+        model_data = 'troop_horse_rider_late_medieval'
     },
     base12 = {
-        name = '4Bw',
+        name = '3Bw',
         base = 'tile_grass_40x20',
-        n_models = 4,
+        loose = true,
+        n_models = 3,
         model_data = 'troop_bowman_late_medieval'
     },
     base13 = {
@@ -1164,6 +1379,13 @@ armies["Book IV"]["IV/82a French Ordonnances 1445-1464AD"] = {
         model_data = 'troop_bowman_late_medieval'
     },
     base14 = {
+        name = '3Bw',
+        base = 'tile_grass_40x20',
+        loose = true,
+        n_models = 3,
+        model_data = 'troop_bowman_late_medieval'
+    },
+    base15 = {
         name = '3Bw',
         base = 'tile_grass_40x20',
         loose = true,
@@ -1177,22 +1399,17 @@ armies["Book IV"]["IV/82a French Ordonnances 1445-1464AD"] = {
         model_data = 'troop_halberdier_late_medieval'
     },
     base16 = {
-        name = 'Art',
-        loose = true,
-        base = 'tile_grass_40x40',
-        n_models = 3,
-        fixed_models = {
-            [1] = 'troop_artillery_crew_late_medieval',
-            [2] = 'troop_artillery_pieces_late_medieval',
-            [3] = 'troop_artillery_crew_late_medieval'
-        }
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_late_medieval'
     },
     base17 = {
         name = '2Ps',
         base = 'tile_grass_40x20',
         loose = true,
         n_models = 2,
-        model_data = 'troop_handgunner_late_medieval'
+        model_data = 'troop_crossbowman_late_medieval'
     },
     base18 = {
         name = 'Art',
@@ -1206,6 +1423,31 @@ armies["Book IV"]["IV/82a French Ordonnances 1445-1464AD"] = {
         }
     },
     base19 = {
+        name = '7Hd',
+        base = 'tile_grass_40x30',
+        loose = true,
+        n_models = 7,
+        model_data = 'troop_horde_late_medieval'
+    },
+    base20 = {
+        name = 'Art',
+        loose = true,
+        base = 'tile_grass_40x40',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_artillery_crew_late_medieval',
+            [2] = 'troop_artillery_pieces_late_medieval',
+            [3] = 'troop_artillery_crew_late_medieval'
+        }
+    },
+    base21 = {
+        name = '7Hd',
+        base = 'tile_grass_40x30',
+        loose = true,
+        n_models = 7,
+        model_data = 'troop_horde_late_medieval'
+    },
+    base22 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -1213,20 +1455,20 @@ armies["Book IV"]["IV/82a French Ordonnances 1445-1464AD"] = {
     },
 }
 
-armies["Book IV"]["IV/82b French Ordonnances 1465-1503AD"] = {
+armies["Book IV"]["IV/82b French Ordonnances 1481-1515AD"] = {
     data = {
         aggresiveness = 2,
         terrain = 'Arable',
-        list = '1x3Kn (Gen), 4x3Kn, 1x3Cv//4Bw, 1x4Cb, 2x4Pk (Swiss if not allies) or 3Bw, 2x2Ps, 1xArt.'
+        list = '1x3Kn, 3x3Kn, 1x3Cv or Mtd-4Lb, 1x2LH, 2x2Ps, 1x7Hd, 2x4Pk, 1xArt'
     },
     base1 = {
         name = '3Kn_Gen',
         base = 'tile_grass_40x30',
         n_models = 3,
         fixed_models = {
-            [1] = 'troop_knight_late_medieval',
+            [1] = 'troop_knight_french_ordonnances_a_bannerman',
             [2] = 'troop_knight_late_medieval_captain',
-            [3] = 'troop_knight_french_ordonnances_b_bannerman'
+            [3] = 'troop_knight_late_medieval'
         }
     },
     base2 = {
@@ -1248,70 +1490,65 @@ armies["Book IV"]["IV/82b French Ordonnances 1465-1503AD"] = {
         model_data = 'troop_knight_late_medieval'
     },
     base5 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
-    },
-    base6 = {
         name = '3Cv',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_horse_rider_late_medieval'
     },
-    base7 = {
-        name = '4Bw',
-        base = 'tile_grass_40x20',
+    base6 = {
+        name = '4Lb_Mtd',
+        base = 'tile_grass_40x40',
         n_models = 4,
-        model_data = 'troop_bowman_late_medieval'
+        model_data = 'troop_horse_rider_late_medieval'
+    },
+    base7 = {
+        name = '2LH',
+        base = 'tile_grass_40x30',
+        n_models = 2,
+        model_data = 'troop_horse_rider_late_medieval'
     },
     base8 = {
-        name = '4Cb',
+        name = '2Ps',
         base = 'tile_grass_40x20',
-        n_models = 3,
+        loose = true,
+        n_models = 2,
         model_data = 'troop_crossbowman_late_medieval'
     },
     base9 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        loose = true,
+        n_models = 2,
+        model_data = 'troop_crossbowman_late_medieval'
+    },
+    base10 = {
+        name = '7Hd',
+        base = 'tile_grass_40x30',
+        loose = true,
+        n_models = 7,
+        fixed_models = {
+            [1] = 'troop_pikeman_late_medieval_inclined',
+            [2] = 'troop_pikeman_late_medieval_straight',
+            [3] = 'troop_pikeman_late_medieval_inclined',
+            [4] = 'troop_pikeman_late_medieval_straight',
+            [5] = 'troop_pikeman_late_medieval_straight',
+            [6] = 'troop_pikeman_late_medieval_inclined',
+            [7] = 'troop_pikeman_late_medieval_straight',
+        }
+    },
+    base11 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_swiss_straight'
     },
-    base10 = {
+    base12 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_swiss_inclined'
     },
-    base11 = {
-        name = '3Bw',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_bowman_late_medieval'
-    },
-    base12 = {
-        name = '3Bw',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_bowman_late_medieval'
-    },
     base13 = {
-        name = '2Ps',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 2,
-        model_data = 'troop_crossbowman_late_medieval'
-    },
-    base14 = {
-        name = '2Ps',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 2,
-        model_data = 'troop_crossbowman_late_medieval'
-    },
-    base15 = {
         name = 'Art',
         loose = true,
         base = 'tile_grass_40x40',
@@ -1322,7 +1559,7 @@ armies["Book IV"]["IV/82b French Ordonnances 1465-1503AD"] = {
             [3] = 'troop_artillery_crew_late_medieval'
         }
     },
-    base16 = {
+    base14 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -1330,11 +1567,11 @@ armies["Book IV"]["IV/82b French Ordonnances 1465-1503AD"] = {
     },
 }
 
-armies["Book IV"]["IV/83a Wars of the Roses English 1455-1485AD"] = {
+armies["Book IV"]["IV/83a Wars of the Roses English 1455-1485AD or Tudor Army 1489-1515AD"] = {
     data = {
         aggresiveness = 1,
         terrain = 'Arable',
-        list = '1x3Kn o 4Bd (Gen), 1x3Kn o 3Cv or 4Bd, 3x4Bd, 6x3/4Lb, 1xArt or 3Sp.'
+        list = '1x3Kn or 4Bd (Gen), 1x3Cv or 2LH or 7Hd, 4x4Bd, 4x4Lb, 1xArt, 1x3Pk or 3Ax or 3Kn//4Bd or 2Ps.'
     },
     base1 = {
         name = '3Kn_Gen',
@@ -1358,22 +1595,22 @@ armies["Book IV"]["IV/83a Wars of the Roses English 1455-1485AD"] = {
         }
     },
     base3 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
-    },
-    base4 = {
         name = '3Cv',
         base = 'tile_grass_40x30',
         n_models = 3,
         model_data = 'troop_horse_rider_late_medieval'
     },
+    base4 = {
+        name = '2LH',
+        base = 'tile_grass_40x30',
+        n_models = 2,
+        model_data = 'troop_horse_rider_late_medieval'
+    },
     base5 = {
-        name = '4Bd',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_halberdier_late_medieval'
+        name = '7Hd',
+        base = 'tile_grass_40x30',
+        n_models = 7,
+        model_data = 'troop_horde_late_medieval'
     },
     base6 = {
         name = '4Bd',
@@ -1394,11 +1631,10 @@ armies["Book IV"]["IV/83a Wars of the Roses English 1455-1485AD"] = {
         model_data = 'troop_halberdier_late_medieval'
     },
     base9 = {
-        name = '3Lb',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_longbowman_late_medieval'
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_late_medieval'
     },
     base10 = {
         name = '4Lb',
@@ -1407,10 +1643,9 @@ armies["Book IV"]["IV/83a Wars of the Roses English 1455-1485AD"] = {
         model_data = 'troop_longbowman_late_medieval'
     },
     base11 = {
-        name = '3Lb',
+        name = '4Lb',
         base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
+        n_models = 4,
         model_data = 'troop_longbowman_late_medieval'
     },
     base12 = {
@@ -1420,19 +1655,12 @@ armies["Book IV"]["IV/83a Wars of the Roses English 1455-1485AD"] = {
         model_data = 'troop_longbowman_late_medieval'
     },
     base13 = {
-        name = '3Lb',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base14 = {
         name = '4Lb',
         base = 'tile_grass_40x20',
         n_models = 4,
         model_data = 'troop_longbowman_late_medieval'
     },
-    base15 = {
+    base14 = {
         name = 'Art',
         loose = true,
         base = 'tile_grass_40x40',
@@ -1443,14 +1671,39 @@ armies["Book IV"]["IV/83a Wars of the Roses English 1455-1485AD"] = {
             [3] = 'troop_artillery_crew_late_medieval'
         }
     },
+    base15 = {
+        name = '3Pk',
+        base = 'tile_grass_40x20',
+        n_models = 3,
+        model_data = 'troop_pikeman_late_medieval'
+    },
     base16 = {
-        name = '3Sp',
+        name = '3Ax',
         base = 'tile_grass_40x20',
         loose = true,
         n_models = 3,
         model_data = 'troop_spearman_no_shield_late_medieval'
     },
     base17 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_late_medieval'
+    },
+    base18 = {
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_late_medieval'
+    },
+    base19 = {
+        name = '2Ps',
+        base = 'tile_grass_40x20',
+        loose = true,
+        n_models = 2,
+        model_data = 'troop_handgunner_late_medieval'
+    },
+    base20 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -1458,20 +1711,21 @@ armies["Book IV"]["IV/83a Wars of the Roses English 1455-1485AD"] = {
     },
 }
 
-armies["Book IV"]["IV/83b Wars of the Roses English 1478AD"] = {
+armies["Book IV"]["IV/83b Wars of the Roses Rebel Army of Henry Tudor 1485AD"] = {
     data = {
         aggresiveness = 1,
         terrain = 'Arable',
-        list = '1x3Kn or 4Bd (Gen), 1x3Kn or 3Cv or 4Bd, 2x4Bd, 1x4Bd or 3Lb, 1xArt or 2Ps, 6x3/4Lb or (2x4Pk+2x3Ax+2x2Ps).'
+        list = '1xCP or 4Bd (Gen), 1x4Bd, 4x4Pk or 4Bd, 3x4Bd, 2x4Lb, 1xArt or 2Ps.'
     },
     base1 = {
-        name = '3Kn_Gen',
-        base = 'tile_grass_40x30',
+        name = '3CP_Gen',
+        base = 'tile_grass_40x40',
         n_models = 3,
+	loose = true,
         fixed_models = {
-            [1] = 'troop_knight_english_wotr_b_bannerman',
+            [1] = 'troop_pikeman_english_wotr_b_bannerman',
             [2] = 'troop_knight_late_medieval_captain',
-            [3] = 'troop_knight_late_medieval'
+            [3] = 'troop_pikeman_english_wotr_b_bannerman'
         }
     },
     base2 = {
@@ -1486,34 +1740,34 @@ armies["Book IV"]["IV/83b Wars of the Roses English 1478AD"] = {
         }
     },
     base3 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_late_medieval'
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_swordman_two_handed_late_medieval'
     },
     base4 = {
-        name = '3Cv',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_horse_rider_late_medieval'
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_late_medieval_straight'
     },
     base5 = {
-        name = '4Bd',
+        name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
-        model_data = 'troop_halberdier_late_medieval'
+        model_data = 'troop_pikeman_late_medieval_straight'
     },
     base6 = {
-        name = '4Bd',
+        name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
-        model_data = 'troop_halberdier_late_medieval'
+        model_data = 'troop_pikeman_late_medieval_inclined'
     },
     base7 = {
-        name = '4Bd',
+        name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
-        model_data = 'troop_halberdier_late_medieval'
+        model_data = 'troop_pikeman_late_medieval_inclined'
     },
     base8 = {
         name = '4Bd',
@@ -1522,13 +1776,54 @@ armies["Book IV"]["IV/83b Wars of the Roses English 1478AD"] = {
         model_data = 'troop_halberdier_late_medieval'
     },
     base9 = {
-        name = '3Lb',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_longbowman_late_medieval'
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_late_medieval'
     },
     base10 = {
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_late_medieval'
+    },
+    base11 = {
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_late_medieval'
+    },
+    base12 = {
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_late_medieval'
+    },
+    base13 = {
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_late_medieval'
+    },
+    base14 = {
+        name = '4Bd',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_halberdier_late_medieval'
+    },
+    base15 = {
+        name = '4Lb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_longbowman_late_medieval'
+    },
+    base16 = {
+        name = '4Lb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_longbowman_late_medieval'
+    },
+    base17 = {
         name = 'Art',
         loose = true,
         base = 'tile_grass_40x40',
@@ -1539,93 +1834,14 @@ armies["Book IV"]["IV/83b Wars of the Roses English 1478AD"] = {
           [3] = 'troop_artillery_crew_late_medieval'
         }
     },
-    base11 = {
+    base18 = {
         name = '2Ps',
         base = 'tile_grass_40x20',
         loose = true,
         n_models = 2,
         model_data = 'troop_handgunner_late_medieval'
     },
-    base12 = {
-        name = '4Lb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base13 = {
-        name = '3Lb',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base14 = {
-        name = '4Lb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base15 = {
-        name = '3Lb',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base16 = {
-        name = '4Lb',
-        base = 'tile_grass_40x20',
-        n_models = 4,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base17 = {
-        name = '3Lb',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_longbowman_late_medieval'
-    },
-    base18 = {
-        name = '4Pk',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_swiss_straight'
-    },
     base19 = {
-        name = '4Pk',
-        base = 'tile_grass_40x15',
-        n_models = 4,
-        model_data = 'troop_pikeman_swiss_inclined'
-    },
-    base20 = {
-        name = '3Sp',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_spearman_no_shield_late_medieval'
-    },
-    base21 = {
-        name = '3Sp',
-        base = 'tile_grass_40x20',
-        loose = true,
-        n_models = 3,
-        model_data = 'troop_spearman_no_shield_late_medieval'
-    },
-    base22 = {
-      name = '2Ps',
-      base = 'tile_grass_40x20',
-      loose = true,
-      n_models = 2,
-      model_data = 'troop_bowman_late_medieval'
-    },
-    base23 = {
-      name = '2Ps',
-      base = 'tile_grass_40x20',
-      loose = true,
-      n_models = 2,
-      model_data = 'troop_crossbowman_late_medieval'
-    },
-    base24 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,
@@ -1633,11 +1849,11 @@ armies["Book IV"]["IV/83b Wars of the Roses English 1478AD"] = {
     },
 }
 
-armies["Book IV"]["IV/84 Burgundian Ordonnance 1471-1477AD"] = {
+armies["Book IV"]["IV/85a Burgundian Ordonnance 1471-1477AD"] = {
     data = {
         aggresiveness = 4,
         terrain = 'Arable',
-        list = '1x3Kn (Gen), 1x3Kn, 3x3Kn//4Bd, 2x4Lb, 1x4Cb, 2x4Pk or 8Bw, 1x2Ps, 1xArt.'
+        list = '1x3Kn//4Bd(Gen), 3x3Kn//4Bd, 3xMtd-4Lb or 4Lb, 1x4Cb, 2x4Pk or 8Lb, 1x2LH or 2Ps or Art or 3Kn, 1xArt.'
     },
 
     base1 = {
@@ -1651,10 +1867,15 @@ armies["Book IV"]["IV/84 Burgundian Ordonnance 1471-1477AD"] = {
         }
     },
     base2 = {
-        name = '3Kn',
-        base = 'tile_grass_40x30',
-        n_models = 3,
-        model_data = 'troop_knight_burgundian_ordonnances'
+        name = '4Bd_Gen',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        fixed_models = {
+            [1] = 'troop_swordman_two_handed_burgundian_ordonnances',
+            [2] = 'troop_pikeman_burgundian_ordonnances_captain',
+            [3] = 'troop_pikeman_burgundian_ordonnances_bannerman',
+            [4] = 'troop_swordman_two_handed_burgundian_ordonnances'
+        }
     },
     base3 = {
         name = '3Kn',
@@ -1693,10 +1914,10 @@ armies["Book IV"]["IV/84 Burgundian Ordonnance 1471-1477AD"] = {
         model_data = 'troop_swordman_two_handed_burgundian_ordonnances'
     },
     base9 = {
-        name = '4Lb',
-        base = 'tile_grass_40x20',
+        name = '4Lb-Mtd',
+        base = 'tile_grass_40x30',
         n_models = 4,
-        model_data = 'troop_longbowman_burgundian_ordonnances'
+        model_data = 'troop_horse_rider_burgundian_ordonnances'
     },
     base10 = {
         name = '4Lb',
@@ -1705,43 +1926,73 @@ armies["Book IV"]["IV/84 Burgundian Ordonnance 1471-1477AD"] = {
         model_data = 'troop_longbowman_burgundian_ordonnances'
     },
     base11 = {
+        name = '4Lb-Mtd',
+        base = 'tile_grass_40x30',
+        n_models = 4,
+        model_data = 'troop_horse_rider_burgundian_ordonnances'
+    },
+    base12 = {
+        name = '4Lb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_longbowman_burgundian_ordonnances'
+    },
+    base13 = {
+        name = '4Lb-Mtd',
+        base = 'tile_grass_40x30',
+        n_models = 4,
+        model_data = 'troop_horse_rider_burgundian_ordonnances'
+    },
+    base14 = {
+        name = '4Lb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_longbowman_burgundian_ordonnances'
+    },
+    base15 = {
         name = '4Cb',
         base = 'tile_grass_40x20',
         n_models = 4,
         model_data = 'troop_crossbowman_burgundian_ordonnances'
     },
-    base12 = {
+    base16 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_burgundian_ordonnances_inclined'
     },
-    base13 = {
+    base17 = {
         name = '4Pk',
         base = 'tile_grass_40x15',
         n_models = 4,
         model_data = 'troop_pikeman_burgundian_ordonnances_straight'
     },
-    base14 = {
-        name = '8Bw',
+    base18 = {
+        name = '8Lb',
         base = 'tile_grass_40x40',
         n_models = 8,
-        model_data = 'troop_bowman_burgundian_ordonnances'
+        model_data = 'troop_longbowman_burgundian_ordonnances'
     },
-    base15 = {
-        name = '8Bw',
+    base19 = {
+        name = '8Lb',
         base = 'tile_grass_40x40',
         n_models = 8,
-        model_data = 'troop_bowman_burgundian_ordonnances'
+        model_data = 'troop_longbowman_burgundian_ordonnances'
     },
-    base16 = {
-        name = '2ps',
+    base20 = {
+        name = '2LH',
+        base = 'tile_grass_40x30',
+        n_models = 2,
+        model_data = 'troop_horse_rider_burgundian_ordonnances'
+    },
+    base21 = {
+        name = '2Ps',
         loose = true,
         base = 'tile_grass_40x20',
         n_models = 2,
         model_data = 'troop_handgunner_burgundian_ordonnances'
     },
-    base17 = {
+    base22 = {
         name = 'Art',
         loose = true,
         base = 'tile_grass_40x40',
@@ -1752,7 +2003,138 @@ armies["Book IV"]["IV/84 Burgundian Ordonnance 1471-1477AD"] = {
             [3] = 'troop_artillery_crew_burgundian_ordonnances'
         }
     },
-    base18 = {
+    base23 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_burgundian_ordonnances'
+    },
+    base24 = {
+        name = 'Art',
+        loose = true,
+        base = 'tile_grass_40x40',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_artillery_crew_burgundian_ordonnances',
+            [2] = 'troop_artillery_pieces_burgundian_ordonnances',
+            [3] = 'troop_artillery_crew_burgundian_ordonnances'
+        }
+    },
+    base25 = {
+        name = 'Camp',
+        base = 'tile_grass_40x40',
+        n_models = 1,
+        model_data = 'troop_camp_burgundian_ordonnances'
+    },
+}
+
+armies["Book IV"]["IV/85b Burgundian Ordonnance 1478-1506AD"] = {
+    data = {
+        aggresiveness = 1,
+        terrain = 'Arable',
+        list = '1x3Kn//4Pk(Gen), 2x2Kn, 1xMtd-4Lb or 4Lb, 1x4Cb, 5x4Pk, 1x2Ps, 1xArt.'
+    },
+
+    base1 = {
+        name = '3Kn_Gen',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_knight_burgundian_ordonnances',
+            [2] = 'troop_knight_burgundian_ordonnances_captain',
+            [3] = 'troop_knight_burgundian_ordonnances_bannerman'
+        }
+    },
+    base2 = {
+        name = '4Pk_Gen',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        fixed_models = {
+            [1] = 'troop_pikeman_two_handed_burgundian_ordonnances',
+            [2] = 'troop_pikeman_burgundian_ordonnances_captain',
+            [3] = 'troop_pikeman_burgundian_ordonnances_bannerman',
+            [4] = 'troop_pikeman_two_handed_burgundian_ordonnances'
+        }
+    },
+    base3 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_burgundian_ordonnances'
+    },
+    base4 = {
+        name = '3Kn',
+        base = 'tile_grass_40x30',
+        n_models = 3,
+        model_data = 'troop_knight_burgundian_ordonnances'
+    },
+    base5 = {
+        name = '4Lb-Mtd',
+        base = 'tile_grass_40x30',
+        n_models = 4,
+        model_data = 'troop_horse_rider_burgundian_ordonnances'
+    },
+    base6 = {
+        name = '4Lb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_longbowman_burgundian_ordonnances'
+    },
+    base7 = {
+        name = '4Cb',
+        base = 'tile_grass_40x20',
+        n_models = 4,
+        model_data = 'troop_crossbowman_burgundian_ordonnances'
+    },
+    base8 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_burgundian_ordonnances_inclined'
+    },
+    base9 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_burgundian_ordonnances_straight'
+    },
+    base10 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_burgundian_ordonnances_straight'
+    },
+    base11 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_burgundian_ordonnances_straight'
+    },
+    base12 = {
+        name = '4Pk',
+        base = 'tile_grass_40x15',
+        n_models = 4,
+        model_data = 'troop_pikeman_burgundian_ordonnances_straight'
+    },
+    base13 = {
+        name = '2Ps',
+        loose = true,
+        base = 'tile_grass_40x20',
+        n_models = 2,
+        model_data = 'troop_handgunner_burgundian_ordonnances'
+    },
+    base14 = {
+        name = 'Art',
+        loose = true,
+        base = 'tile_grass_40x40',
+        n_models = 3,
+        fixed_models = {
+            [1] = 'troop_artillery_crew_burgundian_ordonnances',
+            [2] = 'troop_artillery_pieces_burgundian_ordonnances',
+            [3] = 'troop_artillery_crew_burgundian_ordonnances'
+        }
+    },
+    base15 = {
         name = 'Camp',
         base = 'tile_grass_40x40',
         n_models = 1,

--- a/scripts/data/data_troops.ttslua
+++ b/scripts/data/data_troops.ttslua
@@ -1705,6 +1705,35 @@ troop_pikeman_burgundian_ordonnances_straight = {
     player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509328286193/499DAEB6A3B4B22765F6A8DD27504209E7ABD158/',
     player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509333663668/204186CBDC8E780D6807537F3C8003DCB1071175/'
 }
+
+troop_pikeman_burgundian_ordonnances_bannerman = {
+    height_correction = 0.36,
+    scale = 0.37,
+    rotation = 180,
+    description = 'Burgundian Ordonnances Bannerman',
+    author = 'Burgundian Ordonnances Bannerman, using Empire Spearmen by Vess, Burgundian banners from Wikipedia by Heralder (Burgundian Dukes banner) and Buho07 (Burgundian cross), both under CC BY-SA 3.0, and linen texture from Public Domain (all of this edited by Arkein).',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1018321187642009000/4C87FD4C49268909AA279504DFA196438FB620CF/',
+        'http://cloud-3.steamusercontent.com/ugc/1018321187642009300/F9954FD94CB8171CAF2D23E9482DA00A8978357C/',
+        'http://cloud-3.steamusercontent.com/ugc/1018321187642009565/2F05C3ED80744E8C6128DFA4E5CEBADC6F03DF0B/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509328286193/499DAEB6A3B4B22765F6A8DD27504209E7ABD158/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509333663668/204186CBDC8E780D6807537F3C8003DCB1071175/'
+}
+
+troop_pikeman_burgundian_ordonnances_captain = {
+    height_correction = 0.36,
+    scale = 0.37,
+    rotation = 180,
+    description = 'Burgundian Ordonnances Captain',
+    author = 'Burgundian Ordonnances Captain, using Empire Knights by Vess and Burgundian Cross by Buho07 under CC BY-SA 3.0 (all edited by Arkein).',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1011563720479888273/0FE163F87747C3B6E5BED19C5F99EF3C6733A8DE/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509328286193/499DAEB6A3B4B22765F6A8DD27504209E7ABD158/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509333663668/204186CBDC8E780D6807537F3C8003DCB1071175/'
+}
+
 troop_handgunner_burgundian_ordonnances = {
     height_correction = 0.36,
     scale = 0.37,
@@ -1882,6 +1911,30 @@ troop_artillery_crew_burgundian_ordonnances = {
     player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509328294575/30D845C06BEE80059D82B0A6F87039D0E3DEA7DF/'
 }
 
+troop_horse_rider_burgundian_ordonnances = {
+    height_correction = 0.71,
+    scale = 0.37,
+    rotation = 180,
+    description = 'Burgundian Ordonnances Horse Rider',
+    author = 'Burgundian Ordonnances Horse Rider, using Empire Horse Rider by Vess (edited by Arkein).',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603297484/5F3F8D746BBA1B12757CAC6727E685009F81CEDA/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603297951/111DF0499B2CA870614F527CDAFB772EE56DA363/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603298430/B14DB2A8D7456F25926DA5441993B7A7750364E7/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603298786/1F82CB4B7B0A9BB16AE6280F016B05E31A00D97F/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603299172/0350D20493428E5392C72375CCA27E659C3F7BBA/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603300149/55BD13266159E134E933360B78422B661851A879/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603300569/9879FFC89B7FAEFE7E8D120C8AC40A41DB65FFBC/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603301104/E4021577529CE79C231816B102B9D8BE2D3220C0/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603301597/E0888F6D23AEDB861D988E65EE255BA8E8D4A897/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603302000/78EAA660981FCB35E2C710F9F11C260FD20325D2/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603302385/DF9AA138A32409343E12624A1356AF414CE07553/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603303443/D02EFC330CC3BEB32F2F60FBAA2B3B221B845F29/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509327531288/D514C7A7153B3F056EB475CB4A12280D8BD5B143/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509327557335/16AB88FA9D3947C8A294E38793C91D416872B1C6/'
+}
+
 troop_knight_burgundian_ordonnances = {
     height_correction = 0.71,
     scale = 0.37,
@@ -1899,6 +1952,7 @@ troop_knight_burgundian_ordonnances = {
     player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509327531288/D514C7A7153B3F056EB475CB4A12280D8BD5B143/',
     player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691509327557335/16AB88FA9D3947C8A294E38793C91D416872B1C6/'
 }
+
 troop_knight_burgundian_ordonnances_captain = {
     height_correction = 0.71,
     scale = 0.37,
@@ -1954,7 +2008,7 @@ troop_carthaginian_soldier = {
       author = 'Carthaginian Soldier by Vokuhila, edited by LeberechtReinhold.',
       mesh = {
           'http://cloud-3.steamusercontent.com/ugc/1029581270242167547/5E21B28F3914FE35E92ADAB26C172B6CC66BAD8E/',
-          'http://cloud-3.steamusercontent.com/ugc/1029581270242168241/14DFC084AB1322ED49026A6312268AFBBEFE24D7/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270242168241/14DFC084AB1322ED49026A6312268AFBBEFE24D7/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242169443/A17104C8CBBBD73469132B595A78577207EBA67C/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242169443/A17104C8CBBBD73469132B595A78577207EBA67C/'
@@ -1967,7 +2021,7 @@ troop_carthaginian_soldier = {
       description = 'Carthaginian Cavalry',
       author = 'Carthaginian Cavalry by Vokuhila, edited by LeberechtReinhold.',
       mesh = {
-          'http://cloud-3.steamusercontent.com/ugc/1029581270242172331/49BB06E1B3099E05D3FFE3E0156B64B741E983F5/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270242172331/49BB06E1B3099E05D3FFE3E0156B64B741E983F5/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242170545/CF0C5339D7F4C7A9EAC27F240AA0A00107AB8E41/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242170545/CF0C5339D7F4C7A9EAC27F240AA0A00107AB8E41/'
@@ -1980,7 +2034,7 @@ troop_carthaginian_soldier = {
       description = 'Carthaginian Cavalry General',
       author = 'Carthaginian Cavalry General by Vokuhila, edited by LeberechtReinhold.',
       mesh = {
-          'http://cloud-3.steamusercontent.com/ugc/1029581270242172979/0FEEB3F33C2442C72C4957B48EB29C3E5F722F8D/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270242172979/0FEEB3F33C2442C72C4957B48EB29C3E5F722F8D/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242213204/0E898B9AE0D2BA99778F3B378E73C01529D541E1/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242213204/0E898B9AE0D2BA99778F3B378E73C01529D541E1/'
@@ -1993,7 +2047,7 @@ troop_carthaginian_soldier = {
       description = 'Carthaginian Chariot',
       author = 'Carthaginian Chariot by Vokuhila, edited by LeberechtReinhold.',
       mesh = {
-          'http://cloud-3.steamusercontent.com/ugc/1029581270242207076/1C6CB5F8A19199AC12D306A3A689C2AEDF93FDFA/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270242207076/1C6CB5F8A19199AC12D306A3A689C2AEDF93FDFA/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242206350/AFA0FA7B04F4609D9F4606016E51A60F4379BA45/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242206350/AFA0FA7B04F4609D9F4606016E51A60F4379BA45/'
@@ -2006,7 +2060,7 @@ troop_carthaginian_soldier = {
       description = 'Carthaginian Chariot General',
       author = 'Carthaginian Chariot General by Vokuhila, edited by LeberechtReinhold.',
       mesh = {
-          'http://cloud-3.steamusercontent.com/ugc/1029581270242385722/29C910BD9D2C011EC83F865CC12261471DCDE81E/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270242385722/29C910BD9D2C011EC83F865CC12261471DCDE81E/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242263906/0B23676E04BBBEC956CC1BFEBD483C4A46CEF8A6/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242263906/0B23676E04BBBEC956CC1BFEBD483C4A46CEF8A6/'
@@ -2019,7 +2073,7 @@ troop_carthaginian_soldier = {
       description = 'Carthaginian Light Cavalry',
       author = 'Carthaginian Light Cavalry by Vokuhila, edited by LeberechtReinhold.',
       mesh = {
-          'http://cloud-3.steamusercontent.com/ugc/1029581270242212517/4F65D3A6DCF9148CABB63F7250BE1566E7DE092A/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270242212517/4F65D3A6DCF9148CABB63F7250BE1566E7DE092A/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242207808/E5C75E23F602682D4BF72BC726DDC94A10D1DB61/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242207808/E5C75E23F602682D4BF72BC726DDC94A10D1DB61/'
@@ -2032,7 +2086,7 @@ troop_carthaginian_soldier = {
       description = 'Carthaginian Psiloi',
       author = 'Carthaginian Psiloi by Vokuhila, edited by LeberechtReinhold.',
       mesh = {
-          'http://cloud-3.steamusercontent.com/ugc/1029581270242209240/46C3539AA895A0326FA6A66D4B3DB3CF89945755/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270242209240/46C3539AA895A0326FA6A66D4B3DB3CF89945755/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242208574/8DBF81C6AEEA21AA5F6FC52C56DE77FA41D174C5/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242208574/8DBF81C6AEEA21AA5F6FC52C56DE77FA41D174C5/'
@@ -2045,12 +2099,12 @@ troop_carthaginian_soldier = {
       description = 'Carthaginian Warband',
       author = 'Carthaginian Warband by Vokuhila, edited by LeberechtReinhold.',
       mesh = {
-          'http://cloud-3.steamusercontent.com/ugc/1029581270242211427/C7BE23775BC42E46C21BE88FE3C6E7A5715F80F5/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270242211427/C7BE23775BC42E46C21BE88FE3C6E7A5715F80F5/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242210092/EAA72A4A9EB089E3828EE86D6E831ABDF556B85A/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270242210092/EAA72A4A9EB089E3828EE86D6E831ABDF556B85A/'
   }
-  
+
   troop_carthaginian_camp = {
     height_correction = 0,
     scale = 1.55,
@@ -2058,7 +2112,7 @@ troop_carthaginian_soldier = {
       description = 'Carthaginian Camp',
       author = 'Carthaginian Camp by 0AD, edited by LeberechtReinhold.',
       mesh = {
-          'http://cloud-3.steamusercontent.com/ugc/1029581270244177959/913D444AD166E2ABACD8E255F648615BEA481190/'  
+          'http://cloud-3.steamusercontent.com/ugc/1029581270244177959/913D444AD166E2ABACD8E255F648615BEA481190/'
       },
       player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270244178515/5A238BD04C4CA8491246C8EBF712D8B452A6EF35/',
       player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1029581270244178515/5A238BD04C4CA8491246C8EBF712D8B452A6EF35/'

--- a/scripts/data/data_troops.ttslua
+++ b/scripts/data/data_troops.ttslua
@@ -830,6 +830,38 @@ troop_halberdier_late_medieval = {
     player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
+troop_horde_late_medieval = {
+    height_correction = 0.36,
+    scale = 0.37,
+    rotation = 180,
+    description = 'Late Medieval Spearman Without Shield',
+    author = 'Late Medieval Spearman, using Empire Spearman by Vess (edited by Arkein).',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1012691108385888219/0DED34571B666B38CA1AEC08DE82F31FC6C8D762/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691108385890162/568768D8B80F77B47F59AD461123AAB565F9ACBA/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691108385890468/492080EB672E45CD49ADDD7221FFBFDECCE387FE/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564987005242163/FDE18A737EA15414FD6EE6F0A5DD99871EF6471F/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564987005242463/8B3391ED2E9F22EE8AA36E15151E3383C84D8489/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564883556586580/E57975CC5F4E49567E5705ECF633E367EE1A8CD2/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564883556587148/E64859A80635D21AE10A5A204E6D5B029A47DC29/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603307792/15D5B66CF1275445CBA3810AE85DBF9C556984FA/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603308146/29A5165EE25145148F83BF8E8AAA2B42BF243CFF/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691054073740027/8AA04116664D79207CBECA436834B4E13CE74D98/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603372169/48E82971B69B6FA0329AA4C9B96A94D9FD2A434C/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603372935/5BB8FEB8D566D5A6EBC5EBB3F97A7CC1D4BEDEAB/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564617603373340/9590F076B2419429D3F9F01C4539C0E8D8940FB5/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564883555624932/035642E0FAE5DF4B5CEBC6434BAB41FC18EEF8E0/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564883555625264/2F543EB07AA1B046FA49FCA7C9EF67194D266DD2/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564883555797051/4AE2697986B0CFE0EC207FA349156951B8E04729/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564883555797369/4857D8B7C7A38339F2A619835B2C22069B6684CE/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564883555797646/A5EAF85D5E5D91A5B142E3F9AE63B70BDC9B6C41/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564198059104940/A83C6771034717A199C71F0053106CCED4081D48/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564198059105255/0742BCCB70B4384839675E41E2046A9A8B57BA2E/',
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
+}
+
 troop_bowman_late_medieval = {
     height_correction = 0.36,
     scale = 0.37,


### PR DESCRIPTION
All 3.0 Book 4 armies with 3D models added.

Since 3.0 has more army lists, there may be 2 or 3 extra lists.

I also added to the data_troops new units:
- Horde for generic late medieval
- Burgundian foot captain
- Burgundian foot bannerman
- Burgundian horse rider

All necessary for the new lists.

Also added I/61a and b lists (Early Carthaginian).