### PR TITLE
Hide trees when the obscure a base

### DIFF
--- a/main.ttslua
+++ b/main.ttslua
@@ -27,16 +27,61 @@
 #include scripts/logic
 #include scripts/uievents
 
-function onload()
+
+
+-- Return the string that will be stored when the game is saved.
+function save_game()
+  local data_table = {
+    g_hide_obscurring_terrain=g_hide_obscurring_terrain,
+    g_obscurring_terrain=g_obscurring_terrain
+  }
+  return JSON.encode(data_table)
+end
+
+
+-- Load a saved games daa from the string.
+-- save_state: String returned by save_game
+function load_saved_game(save_state)
+  if save_state == nil then
+    return
+  end
+  local status,saved_data = pcall( function() return JSON.decode(save_state) end)
+  if not status then
+    return
+  end
+  if type(saved_data) ~= 'table' then
+    return
+  end
+  if saved_data['g_hide_obscurring_terrain'] ~= nil then
+    g_hide_obscurring_terrain = saved_data['g_hide_obscurring_terrain']
+  else
+    g_hide_obscurring_terrain = true
+  end
+  if saved_data['g_obscurring_terrain'] ~= nil then
+    g_obscurring_terrain = saved_data['g_obscurring_terrain']
+  else
+    g_obscurring_terrain = {}
+  end
+end
+
+
+function onSave()
+  return save_game()
+end
+
+
+function onload(save_state)
     print_info('----------------------------------------------')
     print_info('                       DBA 3.0 v1.21 ')
     print_info('----------------------------------------------\n\nCheck the Notebook for instructions.')
+    load_saved_game(save_state)
     Wait.time(main_loop, g_seconds_main_loop, -1)
     make_scenery_non_interactable()
     reset_state()
     spawn_proxy_bases()
     spawn_all_dice()
     spawn_dead_zones()
+    set_all_obscurring_terrain_visibility()
 end
 
 function make_scenery_non_interactable()

--- a/scripts/logic.ttslua
+++ b/scripts/logic.ttslua
@@ -78,7 +78,7 @@ function filter_bases(list)
     local filtered = {}
     for _,obj in ipairs(list) do
         local name = obj.getName()
-        if g_bases[name] ~= nil or str_starts_with(obj.getName(), 'base') then
+        if g_bases[name] ~= nil or is_base(obj) then
             table.insert(filtered, obj)
         end
     end
@@ -635,8 +635,8 @@ end
 
 
 function transform_to_shape(transform)
-  corners=transform['corners']
-  shape={
+  local corners=transform['corners']
+  local shape={
     corners['topright'], corners['topleft'], corners['botleft'],
     corners['botright']
   }
@@ -1048,6 +1048,18 @@ function get_size(base_name)
         y = g_base_height_inches,
         z = get_depth_base(tile)
     }
+end
+
+-- Is an object a base (e.g. moving unit?)
+function is_base(obj)
+  if  obj == nil then
+    return false
+  end
+  local name = obj.getName()
+  if name == nil then
+    return false
+  end
+  return str_starts_with(name, "base")
 end
 
 function is_base_red_player(base_name)

--- a/scripts/logic_gizmos.ttslua
+++ b/scripts/logic_gizmos.ttslua
@@ -1074,7 +1074,7 @@ end
 
 function draw_numbers_quadrant(size)
     local height_text = g_table_thickness * 2 + g_base_height_tabletop + g_base_height_inches / 2
-    
+
     spawn_text('1', { -size['x'] / 4, height_text, -size['z'] / 4})
 
     spawn_text('2', { -size['x'] / 4, height_text, size['z'] / 4})
@@ -1225,8 +1225,7 @@ function show_gizmo_bua_afterdetach()
                 table.insert(strokes, strokes_bw)
                 table.insert(strokes, strokes_art)
             end
-            gametable.addAttachment(terrain)
-            print_debug('Reattaching ' .. terrain.getName())
+            terrain.setLock(true)
         end
     end
     print_debug('Recalculation for fire gizmos BUAs done')
@@ -1240,7 +1239,5 @@ function show_gizmo_bua()
         return
     end
 
-    print_info('Showing BUA fire until deselection. All terrain will be reattached.')
-    gametable.removeAttachments()
     Wait.frames(show_gizmo_bua_afterdetach, 1)
 end

--- a/scripts/logic_spawn_army.ttslua
+++ b/scripts/logic_spawn_army.ttslua
@@ -44,6 +44,9 @@ function add_context_menu_table(table_obj)
     table_obj.addContextMenuItem('Toggle BUA fire/ZOC', function()
         show_gizmo_bua()
     end)
+    table_obj.addContextMenuItem('Toggle hide terrain', function()
+        toggle_hide_obscuring_terrain()
+    end)
 end
 
 function toggle_deployment_ruler()

--- a/scripts/logic_terrain.ttslua
+++ b/scripts/logic_terrain.ttslua
@@ -22,7 +22,7 @@ function snap_waterway(waterway)
     local h = bounds['size']['z']
     local zpos = table_h / 2 - (h / 2 - bounds['offset']['z'])
     local xpos = table_w / 2 - (h / 2 - bounds['offset']['z'])
-    if g_is_double_dba then 
+    if g_is_double_dba then
         xpos = xpos + table_w / 2
     end
 
@@ -48,7 +48,7 @@ function snap_waterway(waterway)
         and equals_float(pos['x'], 0, g_max_camp_edge_snap)
         and equals_float(pos['z'], -zpos, g_max_camp_edge_snap)
         then
-            
+
         waterway.setPosition({x=0, y=g_terrain_pos, z=-zpos})
         waterway.setRotation({x=0, y=180, z=0})
         print_info('Waterway Snapping bot')
@@ -57,7 +57,7 @@ function snap_waterway(waterway)
         and equals_float(pos['x'], xpos, g_max_camp_edge_snap)
         and equals_float(pos['z'], 0, g_max_camp_edge_snap)
         then
-            
+
         waterway.setPosition({x=xpos, y=g_terrain_pos, z=0})
         waterway.setRotation({x=0, y=90, z=0})
         print_info('Waterway Snapping right')
@@ -72,7 +72,7 @@ function snap_road(road)
     local rotation = normalize_angle(math.rad(road.getRotation()['y']))
     local pos = road.getPosition()
 
-    if (equals_float(rotation, 0, 0.17) 
+    if (equals_float(rotation, 0, 0.17)
         or equals_float(rotation, math.pi, 0.17)
         or equals_float(rotation, 2*math.pi, 0.17))
         and equals_float(pos['z'], 0, g_max_camp_edge_snap)
@@ -82,7 +82,7 @@ function snap_road(road)
         road.setRotation({x=0, y=0, z=0})
         print_info('Road Snapping Vertical')
 
-    elseif (equals_float(rotation, math.pi/2, 0.17) 
+    elseif (equals_float(rotation, math.pi/2, 0.17)
             or equals_float(rotation, 3*math.pi/2, 0.17))
             and equals_float(pos['x'], 0, g_max_camp_edge_snap)
         then
@@ -146,9 +146,8 @@ function fix_terrain_and_lock()
                 if g_use_3d_terrain then
                     process_vegetation(terrain, terrain_type)
                 end
-    
-                gametable.addAttachment(terrain)
-                print_info('Attaching ' .. terrain.getName())                
+
+                terrain.setLock(true)
             end, 1)
         end
     end
@@ -167,6 +166,106 @@ function change_texture_terrain(terrain_obj, new_tex_url)
     terrain_obj.setCustomObject(custom)
 end
 
+-- Get the colors for the players. e.g. {"Red", "Blue"}
+function get_player_colors()
+  local playerList = Player.getPlayers()
+  local result = {}
+  for i, playerReference in ipairs(playerList) do
+    result[i] = playerReference.color
+  end
+  return result
+end
+
+-- terrain detail that will hide if there is a colliding base.
+-- key is the GUID of terrain detail object (e.g. tree), and the value
+-- is a set GUID's as the key of bases (objects) that are colliding
+-- with the terrain detail.
+--
+-- This structure is serialized when the game is saved, including
+-- auto saved which occurs frequently, which is why we
+-- are using GUID instead of object references.
+g_obscurring_terrain = {}
+
+g_hide_obscurring_terrain = true
+
+
+-- Set the visibility for a piece of terrain that may
+-- obscure bases.
+--
+-- detail: GUID of Object to hide, e.g. tree
+function set_obscurring_terrain_visibility(detail_guid)
+  local terrain_detail = getObjectFromGUID(detail_guid)
+  if terrain_detail == nill then
+      print_debug("terrain detail is nil: " .. terrain_guid)
+      return
+  end
+  terrain_detail.registerCollisions(false)
+  local hide = g_hide_obscurring_terrain and (not is_table_empty(g_obscurring_terrain[detail_guid]))
+  if hide then
+    terrain_detail.setInvisibleTo(get_player_colors())
+  else
+    terrain_detail.setInvisibleTo({})
+  end
+end
+
+-- Set the visibility of all the terrain that can obscure
+-- bases.
+function set_all_obscurring_terrain_visibility()
+  for terrain_guid,_ in pairs(g_obscurring_terrain) do
+    set_obscurring_terrain_visibility(terrain_guid)
+  end
+end
+
+function toggle_hide_obscuring_terrain()
+  g_hide_obscurring_terrain = not g_hide_obscurring_terrain
+  if g_hide_obscurring_terrain then
+    print_info("Obscurring terrain detail will be hidden")
+  else
+    print_info("Obscurring terrain detail will be shown")
+  end
+  set_all_obscurring_terrain_visibility()
+end
+
+function onObjectCollisionEnter(registered_object, info)
+  local collision_object = info.collision_object
+  if not is_base(collision_object) then
+    return
+  end
+  local registered_guid = registered_object.getGUID()
+  local collisions = g_obscurring_terrain[registered_guid]
+  if nil == collisions then
+    return
+  end
+  local colliding_guid = collision_object.getGUID()
+  collisions[colliding_guid] = true
+  if g_hide_obscurring_terrain then
+    registered_object.setInvisibleTo(get_player_colors())
+  else
+    registered_object.setInvisibleTo({})
+  end
+end
+
+function onObjectCollisionExit(registered_object, info)
+  local collision_object = info.collision_object
+  local collisions = g_obscurring_terrain[registered_object.getGUID()]
+  if nil == collisions then
+    return
+  end
+  -- Remove the colliding object from the set of collisions
+  local colliding_guid = collision_object.getGUID()
+  collisions[colliding_guid] = nil
+  if (not g_hide_obscurring_terrain) or is_table_empty(collisions) then
+    registered_object.setInvisibleTo({})
+  end
+end
+
+-- Setup a terrain detail to be able to hide when a base collides
+-- with it.
+function register_obscurring_terrain(obj)
+  g_obscurring_terrain[obj.getGUID()] = {  }
+  obj.registerCollisions(false)
+end
+
 function set_forest(terrain_obj, terrain_pos, terrain_rotation, terrain_size, table_type)
     local options = g_terrain[table_type]['forest']
     local multiplier = options['multiplier']
@@ -175,7 +274,8 @@ function set_forest(terrain_obj, terrain_pos, terrain_rotation, terrain_size, ta
         local point = random_point_ellipse(terrain_size['x'] / 2.5, terrain_size['z'] / 2.5)
         new_pos = rotate_point_relative(point, terrain_pos, terrain_rotation)
         local obj = spawn_model(random_element(options['objects']), new_pos, math.random(1, 359), minimal_collider, true)
-        terrain_obj.addAttachment(obj)
+        obj.setLock(true)
+        register_obscurring_terrain(obj)
     end
     change_texture_terrain(terrain_obj, random_element(options['texture']))
 end
@@ -232,9 +332,9 @@ function set_plough(terrain_obj, terrain_pos, terrain_rotation, terrain_size, ta
 
     for i=1,objs_x do
         for j=1,objs_z do
-            local point = { 
-                x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2, 
-                y = 0, 
+            local point = {
+                x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2,
+                y = 0,
                 z = margin_z + 0.5 + j - 1 - terrain_size['z'] / 2
             }
             local new_pos = rotate_point_relative(point, terrain_pos, terrain_rotation)
@@ -256,9 +356,9 @@ function set_enclosure(terrain_obj, terrain_pos, terrain_rotation, terrain_size,
 
     for i=1,objs_x do
         for j=1,objs_z do
-            local point = { 
-                x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2, 
-                y = 0, 
+            local point = {
+                x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2,
+                y = 0,
                 z = margin_z + 0.5 + j - 1 - terrain_size['z'] / 2
             }
             local new_pos = rotate_point_relative(point, terrain_pos, terrain_rotation)
@@ -269,39 +369,39 @@ function set_enclosure(terrain_obj, terrain_pos, terrain_rotation, terrain_size,
 
     local fence_asset = first_value_table(options['outline_objects'])
     for i=1,objs_x do
-        local point_up = { 
-            x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2, 
-            y = 0, 
+        local point_up = {
+            x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2,
+            y = 0,
             z = terrain_size['z'] / 2 - 0.1
         }
         local new_pos_up = rotate_point_relative(point_up, terrain_pos, terrain_rotation)
-        
+
         local obj_up = spawn_model(fence_asset, new_pos_up, terrain_obj.getRotation()['y'], minimal_collider, true)
         terrain_obj.addAttachment(obj_up)
 
-        local point_down = { 
-            x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2, 
-            y = 0, 
+        local point_down = {
+            x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2,
+            y = 0,
             z = - terrain_size['z'] / 2 + 0.1
         }
         local new_pos_down = rotate_point_relative(point_down, terrain_pos, terrain_rotation)
         local obj_down = spawn_model(fence_asset, new_pos_down, terrain_obj.getRotation()['y'] + 180, minimal_collider, true)
         terrain_obj.addAttachment(obj_down)
     end
-    
+
     for j=1,objs_z do
-        local point_left = { 
-            x = - terrain_size['x'] / 2 + 0.1, 
-            y = 0, 
+        local point_left = {
+            x = - terrain_size['x'] / 2 + 0.1,
+            y = 0,
             z = margin_z + 0.5 + j - 1 - terrain_size['z'] / 2
         }
         local new_pos_left = rotate_point_relative(point_left, terrain_pos, terrain_rotation)
         local obj_left = spawn_model(fence_asset, new_pos_left, terrain_obj.getRotation()['y'] + 90, minimal_collider, true)
         terrain_obj.addAttachment(obj_left)
 
-        local point_right = { 
-            x = terrain_size['x'] / 2 - 0.1, 
-            y = 0, 
+        local point_right = {
+            x = terrain_size['x'] / 2 - 0.1,
+            y = 0,
             z = margin_z + 0.5 + j - 1 - terrain_size['z'] / 2
         }
         local new_pos_right = rotate_point_relative(point_right, terrain_pos, terrain_rotation)

--- a/scripts/utilities_lua.ttslua
+++ b/scripts/utilities_lua.ttslua
@@ -71,10 +71,10 @@ function array_equals(t1, t2, comparison_function)
     if t1 == nil or t2 == nil then
         return false
     end
-    if #t1 ~= #t2 then 
+    if #t1 ~= #t2 then
         return false
     end
-    
+
     for i=1,#t1 do
         if not find_in_array(t2, t1[i], comparison_function) then
             return false
@@ -82,7 +82,7 @@ function array_equals(t1, t2, comparison_function)
     end
     return true
   end
-  
+
 -- Rounds a number to the power of ten given
 -- For example, round_to_power(123, 1) => 120, round_to_power(123, 2) => 100
 function round_to_power(number, power)
@@ -101,10 +101,18 @@ end
 function str_has_substr(str, substr)
     return string.find(str, substr) ~= nil
 end
-  
+
+-- Is a table empty, i.e. tlen(table) == 0
+function is_table_empty(table)
+  for k,v in pairs(table) do
+    return false
+  end
+  return true
+end
+
 -- As insane as it sounds, tables in lua don't have a well-defined way
 -- of getting the number of entries
--- If the table is anything but a contiguous array, the # operator 
+-- If the table is anything but a contiguous array, the # operator
 -- is useless. This computes that.
 -- Beware that this iterates the whole table and is therefore, perf intensive.
 function tlen(table)

--- a/unittests/test_logic.lua
+++ b/unittests/test_logic.lua
@@ -1185,4 +1185,23 @@ function test_transform_to_shape()
   lu.assertEquals(actual[4], corners['botleft'])
 end
 
+function test_is_base_returns_false_for_nil()
+  lu.assertFalse( is_base(nil) )
+end
+
+function test_is_base_returns_false_if_name_is_nil()
+  local base = { getName = function() return nil end }
+  lu.assertFalse( is_base(base) )
+end
+
+function test_is_base_returns_false_if_name_not_starting_with_base()
+  local base = { getName = function() return "abase" end }
+  lu.assertFalse( is_base(base) )
+end
+
+function test_is_base_returns_true_if_name_starting_with_base()
+  local base = { getName = function() return "base bow" end }
+  lu.assertTrue( is_base(base) )
+end
+
 os.exit( lu.LuaUnit.run() )

--- a/unittests/test_logic_colliding_terrain.lua
+++ b/unittests/test_logic_colliding_terrain.lua
@@ -1,0 +1,272 @@
+lu = require('externals/luaunit/luaunit')
+require('scripts/data/data_settings')
+require('scripts/data/data_tables')
+require('scripts/data/data_terrain')
+require('scripts/data/data_troops')
+--require('scripts/data/data_troops_greek_successors')
+--require('scripts/data/data_armies_book_I')
+--require('scripts/data/data_armies_book_II')
+--require('scripts/data/data_armies_book_III')
+--require('scripts/data/data_armies_book_IV')
+require('scripts/base_cache')
+require('scripts/log')
+require('scripts/utilities_lua')
+require('scripts/utilities')
+require('scripts/logic_terrain')
+require('scripts/logic_gizmos')
+require('scripts/logic_spawn_army')
+require('scripts/logic_dead')
+require('scripts/logic_dice')
+require('scripts/logic_history_stack')
+require('scripts/logic')
+require('scripts/uievents')
+
+-- Simulate TTS function
+Player={}
+Player.getPlayers = function()
+  return { {color="Red"}, {color="Blue"} }
+end
+
+function test_terrain_not_invisible_if_colliding_with_not_base()
+  local tree1_invisible = {}
+  local tree1_registered = nil
+  local tree1 = {
+      getName = function() return 'tree1' end,
+      getGUID = function() return 'tree1guid' end,
+      registerCollisions = function(stay)
+          tree1_registered = stay
+        end,
+      setInvisibleTo = function(players) tree1_invisible = players end,
+      }
+  local tree2 = {
+    getName = function() return 'tree2' end,
+    getGUID = function() return 'tree2guid' end,
+  }
+  register_obscurring_terrain(tree1)
+  lu.assertEquals(false, tree1_registered)
+
+  -- Exercise
+  g_hide_obscurring_terrain = true
+  local info = { collision_object=tree2 }
+  onObjectCollisionEnter(tree1, info)
+
+  -- verify
+  lu.assertTrue(is_table_empty(tree1_invisible))
+end
+
+function test_terrain_invisible_if_colliding_with_base()
+  local tree1_invisible = {}
+  local tree1 = {
+      getName = function() return 'tree' end,
+      getGUID = function() return 'guidtree' end,
+      registerCollisions = function(stay) end,
+      setInvisibleTo = function(players) tree1_invisible = players end,
+    }
+  local bow = {
+    getName = function() return 'base bow' end,
+    getGUID = function() return 'guidbow' end
+   }
+  register_obscurring_terrain(tree1)
+
+    -- Exercise
+    g_hide_obscurring_terrain = true
+
+  local info = { collision_object=bow }
+  onObjectCollisionEnter(tree1, info)
+
+  -- Validate
+  lu.assertFalse(is_table_empty( tree1_invisible ) )
+end
+
+function test_terrain_visible_if_colliding_with_base_if_obscurring_terrain_disabled()
+  local tree1_invisible = {}
+  local tree1 = {
+      getName = function() return 'tree' end,
+      getGUID = function() return 'guidtree' end,
+      registerCollisions = function(stay) end,
+      setInvisibleTo = function(players) tree1_invisible = players end,
+    }
+  local bow = {
+    getName = function() return 'base bow' end,
+    getGUID = function() return 'guidbow' end
+   }
+  register_obscurring_terrain(tree1)
+
+  -- Exercise
+  g_hide_obscurring_terrain = false
+  local info = { collision_object=bow }
+  onObjectCollisionEnter(tree1, info)
+
+  -- Validate
+  lu.assertTrue(is_table_empty( tree1_invisible ) )
+end
+
+
+function test_terrain_visible_if_base_leaves()
+  local tree1_invisible = {}
+  local tree1 = {
+      getName = function() return 'tree' end,
+      getGUID = function() return 'guidtree' end,
+      registerCollisions = function(stay) end,
+      setInvisibleTo = function(players) tree1_invisible = players end,
+    }
+  local bow = {
+    getName = function() return 'base bow' end,
+    getGUID = function() return 'guidbow' end
+   }
+  register_obscurring_terrain(tree1)
+
+  -- Exercise
+  g_hide_obscurring_terrain = true
+  local info = { collision_object=bow }
+  onObjectCollisionEnter(tree1, info)
+  lu.assertFalse(is_table_empty( tree1_invisible ) )
+  onObjectCollisionExit(tree1, info)
+
+  -- verify
+  lu.assertTrue(is_table_empty( tree1_invisible ) )
+end
+
+function test_terrain_visible_if_base_leaves_after_multiple_entries()
+  local tree1_invisible = {}
+  local tree1 = {
+      getName = function() return 'tree' end,
+      getGUID = function() return 'guidtree' end,
+      registerCollisions = function(stay) end,
+      setInvisibleTo = function(players) tree1_invisible = players end,
+    }
+  local bow = {
+    getName = function() return 'base bow' end,
+    getGUID = function() return 'guidbow' end
+  }
+  register_obscurring_terrain(tree1)
+
+  -- Exercise
+  g_hide_obscurring_terrain = true
+  local info = { collision_object=bow }
+  onObjectCollisionEnter(tree1, info)
+  onObjectCollisionEnter(tree1, info)
+  onObjectCollisionEnter(tree1, info)
+  onObjectCollisionExit(tree1, info)
+  lu.assertTrue(is_table_empty( tree1_invisible ) )
+end
+
+function test_non_terrain_ignored_for_collision_enter()
+  local bow = {
+    getName = function() return 'base bow' end,
+    getGUID = function() return "guidbow" end
+  }
+  local aux = {
+    getName = function() return 'base aux' end,
+    getGUID = function() return "guidaux" end
+  }
+
+  -- Exercise
+  g_hide_obscurring_terrain = true
+  local info = { collision_object=bow }
+  onObjectCollisionEnter(aux, info)
+end
+
+function test_non_terrain_ignored_for_collision_exit()
+  local bow = {
+    getName = function() return 'base bow' end,
+    getGUID = function() return "guidbow" end
+  }
+  local aux = {
+    getName = function() return 'base aux' end,
+    getGUID = function() return "guidaux" end
+  }
+  -- Exercise
+  g_hide_obscurring_terrain = true
+  local info = { collision_object=bow }
+  onObjectCollisionExit(aux, info)
+end
+
+-- set the visibility of the terrain based on collisions with bases.
+-- Used when loading a saved game.
+function test_set_obscurring_terrain_visibility_hidden()
+-- Setup
+  local tree1_invisible = {}
+  local tree1 = {
+      getName = function() return 'tree' end,
+      getGUID = function() return 'guidtree' end,
+      registerCollisions = function(stay) end,
+      setInvisibleTo = function(players) tree1_invisible = players end,
+    }
+  local bow = {
+    getName = function() return 'base bow' end,
+    getGUID = function() return 'guidbow' end
+   }
+  register_obscurring_terrain(tree1)
+
+  g_hide_obscurring_terrain = true
+  local info = { collision_object=bow }
+  onObjectCollisionEnter(tree1, info)
+
+  getObjectFromGUID =function(guid)
+    if guid == "guidtree" then
+      return tree1
+    end
+    lu.assertFalse(true)  -- test failed
+  end
+
+  -- Exercise
+  tree1_invisible = {}
+  set_obscurring_terrain_visibility('guidtree')
+
+  -- Verify
+  lu.assertFalse(is_table_empty( tree1_invisible ) )
+
+  -- Cleanup
+  getObjectFromGUID = nil
+end
+
+-- set the visibility of the terrain based on collisions with bases.
+-- Used when loading a saved game.
+function test_set_obscurring_terrain_visibility_visible()
+-- Setup
+  local tree1_invisible = {}
+  local tree1 = {
+      getName = function() return 'tree' end,
+      getGUID = function() return 'guidtree' end,
+      registerCollisions = function(stay) end,
+      setInvisibleTo = function(players) tree1_invisible = players end,
+    }
+  local bow = {
+    getName = function() return 'base bow' end,
+    getGUID = function() return 'guidbow' end
+   }
+  register_obscurring_terrain(tree1)
+
+  g_hide_obscurring_terrain = false -- tesing setting
+  local info = { collision_object=bow }
+  onObjectCollisionEnter(tree1, info)
+
+  getObjectFromGUID =function(guid)
+    if guid == "guidtree" then
+      return tree1
+    end
+    lu.assertFalse(true)  -- test failed
+  end
+
+  -- Exercise
+  tree1_invisible = {}
+  set_obscurring_terrain_visibility('guidtree')
+
+  -- Verify
+  lu.assertTrue(is_table_empty( tree1_invisible ) )
+
+  -- Cleanup
+  getObjectFromGUID = nil
+end
+
+--function test_g_hide_obscurring_terrain_loaded_as_false()
+--  g_hide_obscurring_terrain = false
+--  local saved = save_game()
+--  lu.assertEquals( type(saved), "string")
+--  g_hide_obscurring_terrain = true
+--  load_saved_game(saved)
+--  lu.assertFalse(g_hide_obscurring_terrain)
+--end
+
+os.exit( lu.LuaUnit.run() )

--- a/unittests/test_utilities_lua.lua
+++ b/unittests/test_utilities_lua.lua
@@ -1,0 +1,25 @@
+lu = require('externals/luaunit/luaunit')
+require('scripts/utilities_lua')
+
+function test_is_table_empty_returns_true_for_empty()
+  local t = {}
+  lu.assertTrue( is_table_empty(t) )
+end
+
+function test_is_table_empty_returns_false_for_non_empty()
+  local t = {a=4}
+  lu.assertFalse( is_table_empty(t) )
+end
+
+function test_is_table_empty_cannot_have_nil_table()
+  local t = nil
+  local f=function() return is_table_empty(t) end
+  if  pcall(f) then
+    lu.assertTrue(false) -- error is expected
+  else 
+    -- error is expected
+  end
+end
+
+
+os.exit( lu.LuaUnit.run() )


### PR DESCRIPTION
Features:
-- Can be toggled on and off
-- Setting is stored and loaded with the game.

How it works:
-- Instead of changing the terrain by adding a tree as an attachment,
   the tree and the terrain is locked so it cannot be moved.

-- The tree registers for callback when there is a collision.

-- A map from the tree to a set of  bases that collide with the tree is kept.
   When the set is empty the tree is shown, when non-empty the tree
  is hidden.  Making the tree hidden and visisble is done by calling
  Object:setInvisibleTo.

-- The map is kept up to date at all times, so we can just adjust
   the visibility when toggling of hiding terrain.

-- The map is saved and loaded with the game.

Bug:
  https://github.com/leberechtreinhold/dba3_tts/issues/19
  The size of the trees returned in the API is too small, so collisions
  are not detected if a tree's branches hang over a base.  Since there
  is no collision, the tree is not hidden.

See:
https://www.youtube.com/watch?v=R8Iq862mrdw