### PR TITLE
Buildings for BUA

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,58 @@ It's not required, but it's encouraged to put this repo with the name "dba3_tts"
     #include dba3_tts/scripts/dice/pip_blue
     #include dba3_tts/scripts/dice/pip_red
 
+How to add a building to terrain
+--------------------------------
+
+Buildings are placed in Built Up Areas (BUA) when the terrain is locked,
+to make the table look pretty. 
+
+Create a building that has its floor centered at 0,0,0, and have the
+.obj and .jpeg files on the local file system.
+
+Test the files by starting DBA3 in TTS.  Select 
+Objects/Components/Custom/Model.The cursor will change to a chess pawn. 
+Click on the table, which should leave a white dot.  Then click on the
+select menu item.  You should get a dialog for Custom Model. Under Model 
+select your .obj and .jpeg file for Model/Mesh and Defuse/Image, 
+choose local file.  Under Material select Carboard. 
+
+Ensure that the model looks good.
+
+Now we need to scale the model.  We first create a sample lot to place the
+building on.  Objects/Blocks/Red Square, to create a 1x1x1 box.
+
+Click Gizmo/Scale and click on the box.  In the transform dialog change 
+the position of the box to 0,1.16,0 and the scale to
+3,0.25,2.25, and close the dialog.  The building will have to fit 
+on this box, with a bit of space for the front yard and back yard.
+
+Click Gizmo/Scale and click on the building.  Change the position
+to 0,1,0; the building should move on top of the box.  Without 
+exiting the dialog adjust the scale values to the same value (e.g. 0.3),
+so that the building fits comfortably on the box. 
+
+You may now add a BUA area, and lock the table. Spawn an army
+with models.  Compare your new building to the existing buildings.
+Adjust the scaling as desired. Write down the final scale.
+
+Spawn a new model like before but this this time select to have the files
+on the cloud. Write down the URLs on the steam server.
+
+In a text editor open data_terrain.ttsla.  Copy the entry for
+terrain_building_desert_shack, and change the contents to 
+the values for your building.
+
+Find the entry for "bua = { object = {" for the terrain where your
+building fits, and add the variable name as a string.
+
+Test by commenting out the other buildings and have a game with all BUA
+areas on the table, with the BUAs rotated in different directions,
+ond lock the table.  Your building should be enclosed in the BUAs, and
+should not overlap other buildings. 
+Uncomment the other builds, and run the test again.
+
+
 TODO
 ----
 

--- a/main.ttslua
+++ b/main.ttslua
@@ -31,7 +31,22 @@
 #include scripts/logic
 #include scripts/uievents
 
-function onload()
+function onSave()
+  -- building locations
+  local lots = {}
+  for _,obj in pairs( getAllObjects()) do
+    if is_building_zone(obj) then
+      lots[ obj.getGUID()] = obj.getTable("bua_lot")
+    end
+  end
+  local extra = {}
+  extra['building_lots'] = lots
+  local saved_data = JSON.encode(extra)
+  return saved_data
+end
+
+
+function onload(saved_data)
     print_info('----------------------------------------------')
     print_info('                       DBA 3.0 v1.22 ')
     print_info('----------------------------------------------\n\nCheck the Notebook for instructions.')
@@ -41,7 +56,47 @@ function onload()
     spawn_proxy_bases()
     spawn_all_dice()
     spawn_dead_zones()
+    restore_zone_callbacks()
+    restore_extra_data(saved_data)
     print_tool_tip_status()
+end
+
+function restore_extra_data(saved_data)
+  if saved_data == nil then
+    return
+  end
+  local extra = JSON.decode(saved_data)
+  if extra == nil then
+    return
+  end
+  if type(extra) ~= 'table' then
+    return
+  end
+  local lots = extra['building_lots']
+  if lots == nil then
+    print_info('No BUA lots found')
+    return
+  end
+  for guid,table in pairs(lots) do
+    local zone = getObjectFromGUID(guid)
+    if zone == nil then
+      print_error("BUA Zone not found: " .. tostring(guid))
+    else
+      zone.setTable('bua_lot', table)
+    end
+  end
+end
+
+
+-- Set the callbacks for zones
+function restore_zone_callbacks()
+  for _,obj in pairs( getAllObjects()) do
+    if is_building_zone(obj) then
+      setZoneBuaCallback(obj)
+    elseif is_dead_zone(obj) then
+      setZoneDeadCallback(obj)
+    end
+  end
 end
 
 function make_scenery_non_interactable()

--- a/scripts/data/data_cheat_sheet.ttslua
+++ b/scripts/data/data_cheat_sheet.ttslua
@@ -1,6 +1,6 @@
 
 base_tool_tips = {}
---mabase_tool_tips['']= {
+--base_tool_tips['']= {
 --  name = "",
 --  mounted = true,
 --  solid = true,
@@ -507,7 +507,7 @@ base_tool_tips['6Bd'] = {
 base_tool_tips['4Wb'] = {
   name = "Solid Warbands",
   solid = true,
-  combat = { foot = 3, mounted = 3 },
+  combat = { foot = 3, mounted = 2 },
   speed = { GG = 2, BG = 2 },
   can_quick_kill={
     "SCh, Pk, Sp, Bd, Hd, Art and civilians in any going"

--- a/scripts/data/data_terrain.ttslua
+++ b/scripts/data/data_terrain.ttslua
@@ -1,20 +1,20 @@
 g_terrain = {
     desert = {
         forest = {
-            objects = { 
-                'terrain_palm_tree' 
+            objects = {
+                'terrain_palm_tree'
             },
             multiplier = 1.3,
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1022823759371071004/DC4F81C7F92B971C1D1F83F2B12C0DE1E896ABEE/'
             }
         },
         rough = {
-            objects = { 
+            objects = {
                 'terrain_palm_shrubs',
                 'terrain_rock_sand'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1022823759371071004/DC4F81C7F92B971C1D1F83F2B12C0DE1E896ABEE/'
             }
         },
@@ -27,48 +27,57 @@ g_terrain = {
             }
         },
         enclosure = {
-            objects = { 
+            objects = {
                 'terrain_wheat'
             },
             outline_objects = {
                 'terrain_fence'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1294171285965572186/1650492F13F9754194BC57D2CBA0C5AB718CFE56/'
             }
         },
         oasis = {
-            objects = { 
-                'terrain_palm_tree' 
+            objects = {
+                'terrain_palm_tree'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095519/542A46C870B041B7DC4B885E338E2D93D0699A2C/'
             }
         },
         marsh = {
-            objects = { 
-                'terrain_palm_shrubs' 
+            objects = {
+                'terrain_palm_shrubs'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095379/0D3285C74959280FC90BBF4B968884A74740ED32/'
+            }
+        },
+        bua = {
+            objects = {
+                'terrain_building_wooden_shack',
+                'terrain_building_desert_shack'
+            },
+            texture = {
+              'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
             }
         }
     },
     grass = {
         forest = {
-            objects = { 
+            objects = {
                 'terrain_nogal'
             },
             multiplier = 1.5,
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
         rough = {
-            objects = { 
+            objects = {
                 'terrain_rock_grey'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
@@ -81,48 +90,56 @@ g_terrain = {
             }
         },
         enclosure = {
-            objects = { 
+            objects = {
                 'terrain_wheat'
             },
             outline_objects = {
                 'terrain_fence'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1294171285965572186/1650492F13F9754194BC57D2CBA0C5AB718CFE56/'
             }
         },
         oasis = {
-            objects = { 
-                'terrain_palm_tree' 
+            objects = {
+                'terrain_palm_tree'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095519/542A46C870B041B7DC4B885E338E2D93D0699A2C/'
             }
         },
         marsh = {
-            objects = { 
-                'terrain_palm_shrubs' 
+            objects = {
+                'terrain_palm_shrubs'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095379/0D3285C74959280FC90BBF4B968884A74740ED32/'
+            }
+        },
+        bua = {
+            objects = {
+                'terrain_building_wooden_shack'
+            },
+            texture = {
+              'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
             }
         }
     },
     forest = {
         forest = {
-            objects = { 
-                'terrain_fir' 
+            objects = {
+                'terrain_fir'
             },
             multiplier = 2,
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
         rough = {
-            objects = { 
+            objects = {
                 'terrain_rock_grey'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
@@ -135,48 +152,56 @@ g_terrain = {
             }
         },
         enclosure = {
-            objects = { 
+            objects = {
                 'terrain_wheat'
             },
             outline_objects = {
                 'terrain_fence'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1294171285965572186/1650492F13F9754194BC57D2CBA0C5AB718CFE56/'
             }
         },
         oasis = {
-            objects = { 
-                'terrain_palm_tree' 
+            objects = {
+                'terrain_palm_tree'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095519/542A46C870B041B7DC4B885E338E2D93D0699A2C/'
             }
         },
         marsh = {
-            objects = { 
-                'terrain_palm_shrubs' 
+            objects = {
+                'terrain_palm_shrubs'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095379/0D3285C74959280FC90BBF4B968884A74740ED32/'
+            }
+        },
+        bua = {
+            objects = {
+                'terrain_building_medieval_wooden_shack'
+            },
+            texture = {
+              'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
             }
         }
     },
     mountain = {
         forest = {
-            objects = { 
-                'terrain_fir' 
+            objects = {
+                'terrain_fir'
             },
             multiplier = 1.5,
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
         rough = {
-            objects = { 
+            objects = {
                 'terrain_rock_grey'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095379/0D3285C74959280FC90BBF4B968884A74740ED32/'
             }
         },
@@ -189,49 +214,57 @@ g_terrain = {
             }
         },
         enclosure = {
-            objects = { 
+            objects = {
                 'terrain_wheat'
             },
             outline_objects = {
                 'terrain_fence'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1294171285965572186/1650492F13F9754194BC57D2CBA0C5AB718CFE56/'
             }
         },
         oasis = {
-            objects = { 
-                'terrain_palm_tree' 
+            objects = {
+                'terrain_palm_tree'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095519/542A46C870B041B7DC4B885E338E2D93D0699A2C/'
             }
         },
         marsh = {
-            objects = { 
-                'terrain_palm_shrubs' 
+            objects = {
+                'terrain_palm_shrubs'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095519/542A46C870B041B7DC4B885E338E2D93D0699A2C/'
+            }
+        },
+        bua = {
+            objects = {
+                'terrain_building_wooden_shack'
+            },
+            texture = {
+              'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
             }
         }
     },
     steppe = {
         forest = {
-            objects = { 
+            objects = {
                 'terrain_nogal',
-                'terrain_shrub_nogal' 
+                'terrain_shrub_nogal'
             },
             multiplier = 1.5,
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
         rough = {
-            objects = { 
+            objects = {
                 'terrain_rock_grey'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
@@ -244,49 +277,57 @@ g_terrain = {
             }
         },
         enclosure = {
-            objects = { 
+            objects = {
                 'terrain_wheat'
             },
             outline_objects = {
                 'terrain_fence'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1294171285965572186/1650492F13F9754194BC57D2CBA0C5AB718CFE56/'
             }
         },
         oasis = {
-            objects = { 
-                'terrain_palm_tree' 
+            objects = {
+                'terrain_palm_tree'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095519/542A46C870B041B7DC4B885E338E2D93D0699A2C/'
             }
         },
         marsh = {
-            objects = { 
-                'terrain_palm_shrubs' 
+            objects = {
+                'terrain_palm_shrubs'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095379/0D3285C74959280FC90BBF4B968884A74740ED32/'
+            }
+        },
+        bua = {
+            objects = {
+                'terrain_building_wooden_shack'
+            },
+            texture = {
+              'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
             }
         }
     },
     tropical = {
         forest = {
-            objects = { 
+            objects = {
                 'terrain_tree',
-                'terrain_palm_shrubs' 
+                'terrain_palm_shrubs'
             },
             multiplier = 2,
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
         rough = {
-            objects = { 
+            objects = {
                 'terrain_palm_shrubs'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1267149286201969420/6FF3C9E1F3FF49AE28673503D1C73FD7E881F2C0/'
             }
         },
@@ -299,33 +340,84 @@ g_terrain = {
             }
         },
         enclosure = {
-            objects = { 
+            objects = {
                 'terrain_wheat'
             },
             outline_objects = {
                 'terrain_fence'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1294171285965572186/1650492F13F9754194BC57D2CBA0C5AB718CFE56/'
             }
         },
         oasis = {
-            objects = { 
-                'terrain_palm_tree' 
+            objects = {
+                'terrain_palm_tree'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095519/542A46C870B041B7DC4B885E338E2D93D0699A2C/'
             }
         },
         marsh = {
-            objects = { 
-                'terrain_palm_shrubs' 
+            objects = {
+                'terrain_palm_shrubs'
             },
-            texture = { 
+            texture = {
                 'http://cloud-3.steamusercontent.com/ugc/1056604919810095379/0D3285C74959280FC90BBF4B968884A74740ED32/'
+            }
+        },
+        bua = {
+            objects = {
+                'terrain_building_wooden_shack'
+            },
+            texture = {
+              'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
             }
         }
     },
+}
+
+-- Properties for the built up areas.
+-- Key is the guid
+terrain_bua = {}
+-- terrain_bua[guid of bua terrain] = {
+--  habitable_area = { x=width of bua,z=height of bua}
+-- }
+terrain_bua['d6667d'] = {
+  habitable_area = { x=9,z=4.5}
+}
+terrain_bua['b6ab2a'] = {
+  habitable_area = { x=9,z=4.5}
+}
+terrain_bua['968244'] = {
+  habitable_area = { x=5.5,z=5}
+}
+terrain_bua['2e85b3'] = {
+  habitable_area = { x=5.5,z=5}
+}
+terrain_bua['ad6ed9'] = {
+  habitable_area = { x=4,z=4}
+}
+terrain_bua['fd2028'] = {
+  habitable_area = { x=4,z=4}
+}
+terrain_bua['2bf0ba'] = {
+  habitable_area = { x=5.5,z=2.5}
+}
+terrain_bua['c054a7'] = {
+  habitable_area = { x=5.5,z=2.5}
+}
+terrain_bua['59f467'] = {
+  habitable_area = { x=2.5,z=2.5}
+}
+terrain_bua['b1d9ae'] = {
+  habitable_area = { x=2.5,z=2.5}
+}
+terrain_bua['b08499'] = {
+  habitable_area = { x=2.75,z=1.5}
+}
+terrain_bua['97d244'] = {
+  habitable_area = { x=2.75,z=1.5}
 }
 
 terrain_rock_sand = {
@@ -462,4 +554,41 @@ terrain_shrub_nogal = {
         'http://cloud-3.steamusercontent.com/ugc/1666853884552194857/2EAC3F8728CE5FFCE454C57F9E6ED64305E211B6/'
     },
     texture = 'http://cloud-3.steamusercontent.com/ugc/1666853884552195011/EB014AC2051ABD9E900CBF41FBB7B56750486560/'
+}
+
+terrain_building_wooden_shack = {
+    height_correction = 0,
+    scale = 0.3,
+    rotation = 0,
+    description = 'Wooden Shack',
+    author = 'TODO',
+    mesh = {
+      "http://pastebin.com/raw.php?i=j13DYk5N"
+    },
+    texture = "http://i.imgur.com/VQ3gNiK.png",
+}
+
+terrain_building_medieval_wooden_shack = {
+    height_correction = 0,
+    scale = 0.20,
+    rotation = 0,
+    description = 'Medieval Wooden Shack',
+    author = 'seriy00110 https://free3d.com/3d-model/medieval-hut-445193.html',
+    mesh = {
+      "http://cloud-3.steamusercontent.com/ugc/1759190965550146159/6FE834F1798B212511701BA3BBC94F3ECAA16F88/"
+    },
+    texture = "http://cloud-3.steamusercontent.com/ugc/1759190965544632020/CD45C81555FDABCE50A7699E5409A9D74D92CAE1/",
+}
+
+terrain_building_desert_shack = {
+    height_correction = 0,
+    scale = 0.30,
+    rotation = 0,
+    description = 'desert shack',
+    author = 'hjmediastudios https://www.blendswap.com/blend/5749',
+    license = "CC-BY",
+    mesh = {
+      "http://cloud-3.steamusercontent.com/ugc/1759190965551780999/D858D72A142FC40E61050C13A69D5B2E072980A5/",
+    },
+    texture = "http://cloud-3.steamusercontent.com/ugc/1759190965551758295/FD48DC26C437FFFCEB80EC686F6D7F195A5BE24D/"
 }

--- a/scripts/data/data_terrain.ttslua
+++ b/scripts/data/data_terrain.ttslua
@@ -561,7 +561,7 @@ terrain_building_wooden_shack = {
     scale = 0.3,
     rotation = 0,
     description = 'Wooden Shack',
-    author = 'TODO',
+    author = "JamesManhattan's Workshop Various Models - Ruins and Buildings and Rocks https://steamcommunity.com/sharedfiles/filedetails/?id=578880360",
     mesh = {
       "http://pastebin.com/raw.php?i=j13DYk5N"
     },

--- a/scripts/data/data_terrain.ttslua
+++ b/scripts/data/data_terrain.ttslua
@@ -118,7 +118,8 @@ g_terrain = {
         },
         bua = {
             objects = {
-                'terrain_building_wooden_shack'
+              'terrain_building_thatch_building',
+              'terrain_building_wooden_shack'
             },
             texture = {
               'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
@@ -180,7 +181,8 @@ g_terrain = {
         },
         bua = {
             objects = {
-                'terrain_building_medieval_wooden_shack'
+              'terrain_building_thatch_building',
+              'terrain_building_medieval_wooden_shack'
             },
             texture = {
               'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
@@ -305,7 +307,8 @@ g_terrain = {
         },
         bua = {
             objects = {
-                'terrain_building_wooden_shack'
+              'terrain_building_thatch_building',
+              'terrain_building_wooden_shack'
             },
             texture = {
               'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
@@ -368,7 +371,8 @@ g_terrain = {
         },
         bua = {
             objects = {
-                'terrain_building_wooden_shack'
+              'terrain_building_thatch_building',
+              'terrain_building_wooden_shack'
             },
             texture = {
               'http://cloud-3.steamusercontent.com/ugc/1759190965544732048/3F3235AEE3C77F075D1C9C572E7D3339F8C8B914/'
@@ -591,4 +595,17 @@ terrain_building_desert_shack = {
       "http://cloud-3.steamusercontent.com/ugc/1759190965551780999/D858D72A142FC40E61050C13A69D5B2E072980A5/",
     },
     texture = "http://cloud-3.steamusercontent.com/ugc/1759190965551758295/FD48DC26C437FFFCEB80EC686F6D7F195A5BE24D/"
+}
+
+terrain_building_thatch_building = {
+    height_correction = 0,
+    scale = 0.25,
+    rotation = 90,
+    description = 'thatched building',
+    author = "Almega's Workshop Fantasy Town with Modular Building Maps - Based on Phandalin from Lost Mine of Phandelver - (RPG, D&D, 3D, High Detail) https://steamcommunity.com/sharedfiles/filedetails/?id=706099411",
+    --license = "",
+    mesh = {
+      "http://pastebin.com/raw.php?i=MnkvwiVg",
+    },
+    texture = "http://i1374.photobucket.com/albums/ag416/JJMark/House23_zps154d04c0.jpg"
 }

--- a/scripts/logic.ttslua
+++ b/scripts/logic.ttslua
@@ -635,8 +635,12 @@ end
 
 
 function transform_to_shape(transform)
-  corners=transform['corners']
-  shape={
+  local corners=transform['corners']
+  return corners_to_shape(corners)
+end
+
+function corners_to_shape(corners)
+  local shape={
     corners['topright'], corners['topleft'], corners['botleft'],
     corners['botright']
   }
@@ -1049,6 +1053,13 @@ function get_size(base_name)
         z = get_depth_base(tile)
     }
 end
+
+-- Is the object a base?
+function is_base(obj)
+  local obj_name = obj.getName()
+  return str_has_substr(obj_name, 'base')
+end
+
 
 function is_base_red_player(base_name)
     return g_bases[base_name]['is_red_player']

--- a/scripts/logic_dead.ttslua
+++ b/scripts/logic_dead.ttslua
@@ -34,9 +34,14 @@ function spawn_dead_zones_after_deletion()
   g_dead_zones['red'] = create_zone('dead zone red',
                 { x = 0, y = 1.6, z = -27 },
                 { x = 10, y = 1, z = 10 })
+  g_dead_zones['red'].setVar("zone_enter_callback", "onObjectEnterScriptingZoneDead")
+  g_dead_zones['red'].setVar("zone_leave_callback", "onObjectLeaveScriptingZoneDead")
+
   g_dead_zones['blue'] = create_zone('dead zone blue',
                 { x = 0, y = 1.6, z = 27 },
                 { x = 10, y = 1, z = 10 })
+  g_dead_zones['blue'].setVar("zone_enter_callback", "onObjectEnterScriptingZoneDead")
+  g_dead_zones['blue'].setVar("zone_leave_callback", "onObjectLeaveScriptingZoneDead")
 end
 
 
@@ -126,30 +131,56 @@ function callback_zone(zone, name, color)
     end
 end
 
+function onObjectEnterScriptingZoneDead(zone, obj)
+  if not g_updating_zone[zone.getName()] then
+      g_updating_zone[zone.getName()] = true
+      Wait.frames(function() update_zone_value(zone) end, 60)
+  else
+      print_debug('Ignoring dead Enter because already updating')
+  end
+end
+
 function onObjectEnterScriptingZone(zone, obj)
+    print_debug(obj.getName() .. ' entered ' .. zone.getName())
     if not str_has_substr(obj.getName(), 'base') then
         return
     end
-    print_debug(obj.getName() .. ' entered ' .. zone.getName())
-    if not g_updating_zone[zone.getName()] then
-        g_updating_zone[zone.getName()] = true
-        Wait.frames(function() update_zone_value(zone) end, 60)
-    else
-        print_debug('Ignoring dead Enter because already updating')
+    local fn = zone.getVar("zone_enter_callback")
+    if fn == nil then
+      print_error("zone_enter_callback is nil for " .. zone.getName() )
+      return
     end
+    if _G[fn] == nil then
+      print_error("Function not defined " .. fn)
+      return
+    end
+    _G[fn](zone, obj)
+end
+
+function onObjectLeaveScriptingZoneDead(zone, obj)
+  if not g_updating_zone[zone.getName()] then
+      g_updating_zone[zone.getName()] = true
+      Wait.frames(function() update_zone_value(zone) end, 60)
+  else
+      print_debug('Ignoring dead Leave because already updating')
+  end
 end
 
 function onObjectLeaveScriptingZone(zone, obj)
+  print_debug(obj.getName() .. ' left ' .. zone.getName())
     if not str_has_substr(obj.getName(), 'base') then
         return
     end
-    print_debug(obj.getName() .. ' left ' .. zone.getName())
-    if not g_updating_zone[zone.getName()] then
-        g_updating_zone[zone.getName()] = true
-        Wait.frames(function() update_zone_value(zone) end, 60)
-    else
-        print_debug('Ignoring dead Leave because already updating')
+    local fn = zone.getVar("zone_leave_callback")
+    if fn == nil then
+      print_error("zone_leave_callback is nil for " .. zone.getName() )
+      return
     end
+    if _G[fn] == nil then
+      print_error("Function not defined " .. fn)
+      return
+    end
+    _G[fn](zone, obj)
 end
 
 

--- a/scripts/logic_dead.ttslua
+++ b/scripts/logic_dead.ttslua
@@ -1,4 +1,9 @@
 
+function is_dead_zone(obj)
+  local name = obj.getName()
+  return str_starts_with(name, 'dead zone')
+end
+
 function spawn_dead_zones()
     delete_all_dead_zones()
     Wait.frames(function()
@@ -9,11 +14,10 @@ end
 function delete_all_dead_zones()
     local all_objs = getAllObjects()
     for _,obj in ipairs(all_objs) do
-        local name = obj.getName()
-        if str_starts_with(name, 'dead zone') then
-            -- This executes on next frame
-            obj.destroy()
-        end
+      if is_dead_zone(obj) then
+        -- This executes on next frame
+        obj.destroy()
+      end
     end
 end
 
@@ -29,19 +33,23 @@ function create_zone(name, position, size)
     return obj
 end
 
+-- Set the variables for the zone to indicate we are a dead zone.
+function setZoneDeadCallback(obj)
+  obj.setVar("zone_enter_callback", "onObjectEnterScriptingZoneDead")
+  obj.setVar("zone_leave_callback", "onObjectLeaveScriptingZoneDead")
+end
+
 g_dead_zones = {}
 function spawn_dead_zones_after_deletion()
   g_dead_zones['red'] = create_zone('dead zone red',
                 { x = 0, y = 1.6, z = -27 },
                 { x = 10, y = 1, z = 10 })
-  g_dead_zones['red'].setVar("zone_enter_callback", "onObjectEnterScriptingZoneDead")
-  g_dead_zones['red'].setVar("zone_leave_callback", "onObjectLeaveScriptingZoneDead")
+  setZoneDeadCallback(g_dead_zones['red'])
 
   g_dead_zones['blue'] = create_zone('dead zone blue',
                 { x = 0, y = 1.6, z = 27 },
                 { x = 10, y = 1, z = 10 })
-  g_dead_zones['blue'].setVar("zone_enter_callback", "onObjectEnterScriptingZoneDead")
-  g_dead_zones['blue'].setVar("zone_leave_callback", "onObjectLeaveScriptingZoneDead")
+  setZoneDeadCallback(g_dead_zones['blue'])
 end
 
 
@@ -147,7 +155,7 @@ function onObjectEnterScriptingZone(zone, obj)
     end
     local fn = zone.getVar("zone_enter_callback")
     if fn == nil then
-      print_error("zone_enter_callback is nil for " .. zone.getName() )
+      print_debug("zone_enter_callback is nil for " .. zone.getName() )
       return
     end
     if _G[fn] == nil then
@@ -173,7 +181,7 @@ function onObjectLeaveScriptingZone(zone, obj)
     end
     local fn = zone.getVar("zone_leave_callback")
     if fn == nil then
-      print_error("zone_leave_callback is nil for " .. zone.getName() )
+      print_debug("zone_leave_callback is nil for " .. zone.getName() )
       return
     end
     if _G[fn] == nil then

--- a/scripts/logic_spawn_army.ttslua
+++ b/scripts/logic_spawn_army.ttslua
@@ -488,6 +488,17 @@ function spawn_model(troop_name, pos, added_y_axis_rotation, collider, is_player
     -- Better pray that the input name actually exists! lol
     local model_data = _G[troop_name]
 
+    -- Show the author so we are in compliance with CC-BY licence
+    if not model_data['copyright_shown'] then
+      model_data['copyright_shown'] = true
+      local copyright = model_data['copyright']
+      if copyright == nil then
+        copyright = ""
+      end
+      if model_data['author'] ~= nil then
+        print_info(tostring(model_data['description']) .. " by " .. tostring(model_data['author']) .. copyright)
+      end
+    end
     local texture = overridden_tex
     if texture == nil then
         texture = model_data['player_blue_tex']

--- a/scripts/logic_terrain.ttslua
+++ b/scripts/logic_terrain.ttslua
@@ -22,7 +22,7 @@ function snap_waterway(waterway)
     local h = bounds['size']['z']
     local zpos = table_h / 2 - (h / 2 - bounds['offset']['z'])
     local xpos = table_w / 2 - (h / 2 - bounds['offset']['z'])
-    if g_is_double_dba then 
+    if g_is_double_dba then
         xpos = xpos + table_w / 2
     end
 
@@ -48,7 +48,7 @@ function snap_waterway(waterway)
         and equals_float(pos['x'], 0, g_max_camp_edge_snap)
         and equals_float(pos['z'], -zpos, g_max_camp_edge_snap)
         then
-            
+
         waterway.setPosition({x=0, y=g_terrain_pos, z=-zpos})
         waterway.setRotation({x=0, y=180, z=0})
         print_info('Waterway Snapping bot')
@@ -57,7 +57,7 @@ function snap_waterway(waterway)
         and equals_float(pos['x'], xpos, g_max_camp_edge_snap)
         and equals_float(pos['z'], 0, g_max_camp_edge_snap)
         then
-            
+
         waterway.setPosition({x=xpos, y=g_terrain_pos, z=0})
         waterway.setRotation({x=0, y=90, z=0})
         print_info('Waterway Snapping right')
@@ -72,7 +72,7 @@ function snap_road(road)
     local rotation = normalize_angle(math.rad(road.getRotation()['y']))
     local pos = road.getPosition()
 
-    if (equals_float(rotation, 0, 0.17) 
+    if (equals_float(rotation, 0, 0.17)
         or equals_float(rotation, math.pi, 0.17)
         or equals_float(rotation, 2*math.pi, 0.17))
         and equals_float(pos['z'], 0, g_max_camp_edge_snap)
@@ -82,7 +82,7 @@ function snap_road(road)
         road.setRotation({x=0, y=0, z=0})
         print_info('Road Snapping Vertical')
 
-    elseif (equals_float(rotation, math.pi/2, 0.17) 
+    elseif (equals_float(rotation, math.pi/2, 0.17)
             or equals_float(rotation, 3*math.pi/2, 0.17))
             and equals_float(pos['x'], 0, g_max_camp_edge_snap)
         then
@@ -146,9 +146,9 @@ function fix_terrain_and_lock()
                 if g_use_3d_terrain then
                     process_vegetation(terrain, terrain_type)
                 end
-    
+
                 gametable.addAttachment(terrain)
-                print_info('Attaching ' .. terrain.getName())                
+                print_info('Attaching ' .. terrain.getName())
             end, 1)
         end
     end
@@ -232,9 +232,9 @@ function set_plough(terrain_obj, terrain_pos, terrain_rotation, terrain_size, ta
 
     for i=1,objs_x do
         for j=1,objs_z do
-            local point = { 
-                x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2, 
-                y = 0, 
+            local point = {
+                x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2,
+                y = 0,
                 z = margin_z + 0.5 + j - 1 - terrain_size['z'] / 2
             }
             local new_pos = rotate_point_relative(point, terrain_pos, terrain_rotation)
@@ -243,6 +243,234 @@ function set_plough(terrain_obj, terrain_pos, terrain_rotation, terrain_size, ta
         end
     end
     change_texture_terrain(terrain_obj, random_element(options['texture']))
+end
+
+
+-- Is the object a building?
+function is_building(obj)
+  local obj_name = obj.getName()
+  return str_has_substr(obj_name, 'building #')
+end
+
+function is_any_base_in_zone(zone)
+  for _,obj in pairs(zone.getObjects()) do
+    if is_base(obj) then
+      return true
+    end
+  end
+  return false
+end
+
+
+function remove_colliding_buildings(zone)
+  if not is_any_base_in_zone(zone) then
+    return
+  end
+  local bua_lot = zone.getTable("bua_lot")
+  if bua_lot == nil then
+    print_error("bua_lot is nil")
+    return
+  end
+  if bua_lot.building_guid == nil then
+    print_debug("building_guid is nil")
+    return
+  end
+  local building = getObjectFromGUID(bua_lot.building_guid)
+  if building == nil then
+    print_debug("building is nil: " .. bua_lot.building_guid)
+    return
+  end
+  bua_lot.building_guid = nil
+  destroyObject(building)
+  zone.setTable("bua_lot", bua_lot)
+end
+
+function restore_buildings(zone)
+  if is_any_base_in_zone(zone) then
+    print_error("zone has a base")
+    return
+  end
+  local bua_lot = zone.getTable("bua_lot")
+  if bua_lot == nil then
+    print_error("bua_lot is nil")
+    return
+  end
+  spawn_building(bua_lot)
+  zone.setTable("bua_lot", bua_lot)
+end
+
+function onObjectEnterScriptingZoneBuaPlot(zone,obj)
+  remove_colliding_buildings(zone)
+end
+
+function stop_zone_timer(zone)
+  local timer_id = zone.getVar("timer")
+  if timer_id ~= nil then
+    -- stop the existing timer
+    Wait.stop(timer_id)
+    zone.setVar("timer", nil)
+  end
+end
+
+function start_zone_timer(zone)
+  stop_zone_timer(zone)
+  timer_id = Wait.time(function ()
+    restore_buildings(zone)
+  end, 3, 1)
+  zone.setVar("timer", timer_id)
+end
+
+function onObjectLeaveScriptingZoneBuaPlot(zone,obj)
+  stop_zone_timer(zone)
+  if is_any_base_in_zone(zone) then
+    return
+  end
+  -- in the future restore the building.
+  start_zone_timer(zone)
+end
+
+
+
+function create_bua_lot_zone(bua_lot, name)
+
+  local size = shallow_copy(bua_lot.size)
+  size.y = 4
+  local zone_spawn = {
+    position = bua_lot.position,
+    rotation = bua_lot.rotation,
+    scale = size,
+    type = 'ScriptingTrigger'
+  }
+  local obj = spawnObject(zone_spawn)
+  obj.setName(name)
+  obj.setLock(true)
+
+  obj.setTable("bua_lot", bua_lot)
+  obj.setVar("zone_enter_callback", "onObjectEnterScriptingZoneBuaPlot")
+  obj.setVar("zone_leave_callback", "onObjectLeaveScriptingZoneBuaPlot")
+
+  print_debug("bua zone created: " .. obj.getGUID())
+  return obj
+end
+
+-- Add a building to a lot, so BUA has some buildings to show
+function spawn_building(lot)
+  local building = spawn_model(
+    lot.model_name,
+    lot.position,
+    lot.rotation.y,
+    minimal_collider, true)
+  building.setName(lot.name)
+  building.setLock(true)
+  lot.building_guid = building.getGUID()
+  return building
+end
+
+g_building_number = 1
+
+
+-- Find the location of buildings for a built up area.
+-- terrain_obj: Built Up Area that is to have buildings placed onto it.
+-- return: Structure describing the location of the buildings.
+function calc_bua_lots(terrain_obj)
+  local lots = {}
+
+  local bua_properties = terrain_bua[terrain_obj.getGUID()]
+  if bua_properties == nil then
+    print_error("terrain_bua not found: " .. terrain_obj.getGUID())
+    return lots
+  end
+  local terrain_size = bua_properties['habitable_area']
+  if terrain_size == nil then
+    print_error("habitable_area not found: " .. terrain_obj.getGUID())
+    return lots
+  end
+
+  local lot_size = {x = 3,y=0, z= 2.25} -- size of land for a building
+  local nb_cols = math.floor(terrain_size.x / lot_size.x)
+  local nb_rows = math.floor(terrain_size.z / lot_size.z)
+  if (nb_cols < 1) then
+    lot_size.x = 0
+    nb_cols = 1
+  elseif nb_rows > 3 then
+      nb_rows = 3
+  end
+  if (nb_rows <1) then
+    lot_size.z = 0
+    nb_rows = 1
+  elseif nb_cols > 3 then
+    nb_cols = 3
+  end
+
+  local terrain_pos = terrain_obj.getPosition()
+  -- in degrees
+  local terrain_rotation = terrain_obj.getRotation()
+  -- in radians
+  local terrain_rotation_y = - math.rad(terrain_rotation.y)
+
+  -- print("nb_rows (z): ", nb_rows)
+  -- print("nb_cols (x): ", nb_cols)
+  local z = -(lot_size.z/2) * (nb_rows-1)
+  for row = 1,nb_rows do
+    local x = -(lot_size.x/2) * (nb_cols-1)
+    for col = 1,nb_cols do
+      local point = {x=x, y=0, z=z}
+      -- print("row ", row, " col ", col, " center ", x, ' ', z)
+      local new_pos = rotate_point_relative(point, terrain_pos, terrain_rotation_y)
+      local rotation_y =  normalize_degrees(terrain_rotation.y + (180 * ((row+1) % 2)))
+      local corners = compute_corners_coords(lot_size, rotation_y, new_pos)
+      local name = "building # " .. tostring(g_building_number)
+      g_building_number = g_building_number + 1
+      local lot = {
+        name = name,
+        position = new_pos,
+        rotation = { x=terrain_rotation.x, y=rotation_y, z=terrain_rotation.z},
+        size = lot_size,
+        shape = corners_to_shape(corners)
+      }
+      table.insert(lots, lot)
+      x = x + lot_size.x
+    end
+    z = z + lot_size.z
+  end
+  return lots
+end
+
+-- Add buildings to the Built Up Area (BUA) to make it look pretty.
+-- terrain_obj: template of the BUA
+-- terrain_rotation: float, y-axis rotation of BUA in radians
+-- options: Source of data for BUA for the table type
+function add_buildings(terrain_obj, terrain_rotation, options)
+  local lots = calc_bua_lots(terrain_obj)
+  for _,lot in pairs(lots) do
+    lot.model_name = random_element(options['objects'])
+    spawn_building(lot)
+
+    -- Cube to show center of the bua_lot. (DEBUGGING ONLY)
+    -- The building should be in the center of the building.
+    -- local cube = spawnObject({
+    --   position = lot.position,
+    --   rotation = lot.rotation,
+    --   scale = {x=0.25,y=5,z=0.25},
+    --   type = 'BlockSquare' }
+    -- )
+    -- cube.setLock(true)
+    -- cube.setColorTint({r=0,g=1,b=0,a=0.5})
+    -- print("cube ")
+    -- table_print(lot.position)
+    -- table_print(lot.rotation)
+    -- table_print(lot.size)
+
+    local zone_name = "zone bua building " .. terrain_obj.getGUID()
+    create_bua_lot_zone(lot, zone_name)
+  end
+end
+
+function set_bua(terrain_obj, terrain_pos, terrain_rotation, terrain_size, table_type)
+  local options = g_terrain[table_type]['bua']
+  change_texture_terrain(terrain_obj, random_element(options['texture']))
+  terrain_obj.setLock(true)
+  add_buildings(terrain_obj, terrain_rotation, options)
 end
 
 function set_enclosure(terrain_obj, terrain_pos, terrain_rotation, terrain_size, table_type)
@@ -256,9 +484,9 @@ function set_enclosure(terrain_obj, terrain_pos, terrain_rotation, terrain_size,
 
     for i=1,objs_x do
         for j=1,objs_z do
-            local point = { 
-                x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2, 
-                y = 0, 
+            local point = {
+                x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2,
+                y = 0,
                 z = margin_z + 0.5 + j - 1 - terrain_size['z'] / 2
             }
             local new_pos = rotate_point_relative(point, terrain_pos, terrain_rotation)
@@ -269,39 +497,39 @@ function set_enclosure(terrain_obj, terrain_pos, terrain_rotation, terrain_size,
 
     local fence_asset = first_value_table(options['outline_objects'])
     for i=1,objs_x do
-        local point_up = { 
-            x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2, 
-            y = 0, 
+        local point_up = {
+            x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2,
+            y = 0,
             z = terrain_size['z'] / 2 - 0.1
         }
         local new_pos_up = rotate_point_relative(point_up, terrain_pos, terrain_rotation)
-        
+
         local obj_up = spawn_model(fence_asset, new_pos_up, terrain_obj.getRotation()['y'], minimal_collider, true)
         terrain_obj.addAttachment(obj_up)
 
-        local point_down = { 
-            x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2, 
-            y = 0, 
+        local point_down = {
+            x = margin_x + 0.5 + i - 1 - terrain_size['x'] / 2,
+            y = 0,
             z = - terrain_size['z'] / 2 + 0.1
         }
         local new_pos_down = rotate_point_relative(point_down, terrain_pos, terrain_rotation)
         local obj_down = spawn_model(fence_asset, new_pos_down, terrain_obj.getRotation()['y'] + 180, minimal_collider, true)
         terrain_obj.addAttachment(obj_down)
     end
-    
+
     for j=1,objs_z do
-        local point_left = { 
-            x = - terrain_size['x'] / 2 + 0.1, 
-            y = 0, 
+        local point_left = {
+            x = - terrain_size['x'] / 2 + 0.1,
+            y = 0,
             z = margin_z + 0.5 + j - 1 - terrain_size['z'] / 2
         }
         local new_pos_left = rotate_point_relative(point_left, terrain_pos, terrain_rotation)
         local obj_left = spawn_model(fence_asset, new_pos_left, terrain_obj.getRotation()['y'] + 90, minimal_collider, true)
         terrain_obj.addAttachment(obj_left)
 
-        local point_right = { 
-            x = terrain_size['x'] / 2 - 0.1, 
-            y = 0, 
+        local point_right = {
+            x = terrain_size['x'] / 2 - 0.1,
+            y = 0,
             z = margin_z + 0.5 + j - 1 - terrain_size['z'] / 2
         }
         local new_pos_right = rotate_point_relative(point_right, terrain_pos, terrain_rotation)
@@ -317,20 +545,17 @@ function process_vegetation(terrain_obj, type)
     local terrain_size = terrain_obj.getBoundsNormalized()['size']
     if str_starts_with(terrain_obj.getName(), 'terrain Forest') then
         set_forest(terrain_obj, terrain_pos, terrain_rotation, terrain_size, type)
-    end
-    if str_starts_with(terrain_obj.getName(), 'terrain Arid') then
+    elseif str_starts_with(terrain_obj.getName(), 'terrain Arid') then
         set_arid(terrain_obj, terrain_pos, terrain_rotation, terrain_size, type)
-    end
-    if str_starts_with(terrain_obj.getName(), 'terrain Oasis') then
+    elseif str_starts_with(terrain_obj.getName(), 'terrain Oasis') then
         set_oasis(terrain_obj, terrain_pos, terrain_rotation, terrain_size, type)
-    end
-    if str_starts_with(terrain_obj.getName(), 'terrain Plough') then
+    elseif str_starts_with(terrain_obj.getName(), 'terrain Plough') then
         set_plough(terrain_obj, terrain_pos, terrain_rotation, terrain_size, type)
-    end
-    if str_starts_with(terrain_obj.getName(), 'terrain Enclosure') then
+    elseif str_starts_with(terrain_obj.getName(), 'terrain Enclosure') then
         set_enclosure(terrain_obj, terrain_pos, terrain_rotation, terrain_size, type)
-    end
-    if str_starts_with(terrain_obj.getName(), 'terrain Marsh') then
+    elseif str_starts_with(terrain_obj.getName(), 'terrain Marsh') then
         set_marsh(terrain_obj, terrain_pos, terrain_rotation, terrain_size, type)
+    elseif str_starts_with(terrain_obj.getName(), 'terrain BUA') then
+          set_bua(terrain_obj, terrain_pos, terrain_rotation, terrain_size, type)
     end
 end

--- a/scripts/logic_terrain.ttslua
+++ b/scripts/logic_terrain.ttslua
@@ -245,11 +245,16 @@ function set_plough(terrain_obj, terrain_pos, terrain_rotation, terrain_size, ta
     change_texture_terrain(terrain_obj, random_element(options['texture']))
 end
 
+-- Is the object a building scripting zone
+function is_building_zone(obj)
+  local obj_name = obj.getName()
+  return str_starts_with(obj_name, 'zone bua building ')
+end
 
 -- Is the object a building?
 function is_building(obj)
   local obj_name = obj.getName()
-  return str_has_substr(obj_name, 'building #')
+  return str_starts_with(obj_name, 'building #')
 end
 
 function is_any_base_in_zone(zone)
@@ -287,7 +292,7 @@ end
 
 function restore_buildings(zone)
   if is_any_base_in_zone(zone) then
-    print_error("zone has a base")
+    print_debug("zone has a base")
     return
   end
   local bua_lot = zone.getTable("bua_lot")
@@ -299,7 +304,7 @@ function restore_buildings(zone)
   zone.setTable("bua_lot", bua_lot)
 end
 
-function onObjectEnterScriptingZoneBuaPlot(zone,obj)
+function onObjectEnterScriptingZoneBuaLot(zone,obj)
   remove_colliding_buildings(zone)
 end
 
@@ -320,7 +325,7 @@ function start_zone_timer(zone)
   zone.setVar("timer", timer_id)
 end
 
-function onObjectLeaveScriptingZoneBuaPlot(zone,obj)
+function onObjectLeaveScriptingZoneBuaLot(zone,obj)
   stop_zone_timer(zone)
   if is_any_base_in_zone(zone) then
     return
@@ -329,7 +334,11 @@ function onObjectLeaveScriptingZoneBuaPlot(zone,obj)
   start_zone_timer(zone)
 end
 
-
+-- Set the variables for the zone to indicate we are a building zone.
+function setZoneBuaCallback(obj)
+  obj.setVar("zone_enter_callback", "onObjectEnterScriptingZoneBuaLot")
+  obj.setVar("zone_leave_callback", "onObjectLeaveScriptingZoneBuaLot")
+end
 
 function create_bua_lot_zone(bua_lot, name)
 
@@ -346,8 +355,7 @@ function create_bua_lot_zone(bua_lot, name)
   obj.setLock(true)
 
   obj.setTable("bua_lot", bua_lot)
-  obj.setVar("zone_enter_callback", "onObjectEnterScriptingZoneBuaPlot")
-  obj.setVar("zone_leave_callback", "onObjectLeaveScriptingZoneBuaPlot")
+  setZoneBuaCallback(obj)
 
   print_debug("bua zone created: " .. obj.getGUID())
   return obj


### PR DESCRIPTION
Have BUA show buildings when the terrain is locked.

The buildings are destroyed when a base intersects them, otherwise the base would be obscured (could be entirely in a building).  When there is no base intersecting the building location, the building is respawned again.

The detection of intersections is done using scripting zones.  This required a small tweak to dead zones.