### PR TITLE
Filter out non-bases when reorganizing casualty zone

### DIFF
--- a/scripts/logic.ttslua
+++ b/scripts/logic.ttslua
@@ -72,13 +72,19 @@ function align_two_bases(base2, position, corners, rotation)
     }
 end
 
+-- Is the base an object
+function is_base_obj(obj)
+  local name = obj.getName()
+  return  g_bases[name] ~= nil or str_starts_with(obj.getName(), 'base')
+end
+
 -- Given a list of objects in a table, returns another table with ONLY
 -- those who start with 'base', ignoring the keys
 function filter_bases(list)
     local filtered = {}
     for _,obj in ipairs(list) do
         local name = obj.getName()
-        if g_bases[name] ~= nil or str_starts_with(obj.getName(), 'base') then
+        if is_base_obj(obj) then
             table.insert(filtered, obj)
         end
     end

--- a/scripts/logic_dead.ttslua
+++ b/scripts/logic_dead.ttslua
@@ -181,29 +181,34 @@ function reorganize_dead_zone(dead_zone)
   local row_contents = {}
   local col  = 1
   local row = 1
-  for _,base in pairs(dead) do
-    base.setRotation(rotation)
-    if (col == 1) and (row == 1) then
-        local base_pos = {x=side_margin, y = g_graveyard_y_pos, z=top}
-        base.setPosition(base_pos)
+  for _,obj in pairs(dead) do
+    if not is_base_obj(obj) then
+      print_important("Only bases should be in casualty area")
     else
-      local dir
-      local other
-      if (row == 1) then
-        other = row_contents[col-1]
-        dir = "left"
+      local base = obj
+      base.setRotation(rotation)
+      if (col == 1) and (row == 1) then
+          local base_pos = {x=side_margin, y = g_graveyard_y_pos, z=top}
+          base.setPosition(base_pos)
       else
-        other = row_contents[col]
-        dir = "behind"
+        local dir
+        local other
+        if (row == 1) then
+          other = row_contents[col-1]
+          dir = "left"
+        else
+          other = row_contents[col]
+          dir = "behind"
+        end
+        snap_to_base(base,calculate_transform(base),other,calculate_transform(other),dir)
       end
-      snap_to_base(base,calculate_transform(base),other,calculate_transform(other),dir)
-    end
-    row_contents[col] = base
-     if col == 5 then
-       col = 1
-       row = row + 1
-     else
-       col = col  + 1
+      row_contents[col] = base
+       if col == 5 then
+         col = 1
+         row = row + 1
+       else
+         col = col  + 1
+       end
      end
   end
 end


### PR DESCRIPTION
Non-base objects may not have the methods that are used for
calculating size and position of where the casualties are
to be placed.

The pcall would catch and report an error, but it did not help the user know what was wrong.

Test case is to insert dice into the casualties area and the use the context menu for set dead.